### PR TITLE
Add setup.sh script for Node.js 20 and Foundry provisioning

### DIFF
--- a/hype-usdc-dnmm/README.md
+++ b/hype-usdc-dnmm/README.md
@@ -13,7 +13,7 @@ End-to-end research and engineering drop for a Lifinity v2–style dynamic no-ma
 
 ## Quick Start
 
-1. Install Foundry (`curl -L https://foundry.paradigm.xyz | bash`) and run `foundryup`.
+1. Run `./setup.sh` from the repo root to provision Node.js 20 and Foundry.
 2. From this folder run `terragon-forge.sh install` commands as needed (wrapper passes `--root hype-usdc-dnmm`).
 3. Configure HyperCore + Pyth identifiers under `config/oracle.ids.json` and token metadata under `config/tokens.hyper.json`.
 4. Execute `terragon-forge.sh test` for the default suite or `terragon-forge.sh test --match-test testFeeDecay` to focus on a component.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for readability
+GREEN="\033[0;32m"
+RESET="\033[0m"
+
+log() {
+  printf "${GREEN}[*] %s${RESET}\n" "$1"
+}
+
+# --- Node.js via nvm ---
+NVM_VERSION="v0.40.3"
+NODE_VERSION="20"
+NVM_DIR="${HOME}/.nvm"
+
+if ! command -v node >/dev/null 2>&1; then
+  log "Node.js not detected; installing nvm ${NVM_VERSION}"
+fi
+
+if [ ! -d "${NVM_DIR}" ]; then
+  curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash
+fi
+
+# shellcheck disable=SC1091
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${NVM_DIR}/nvm.sh"
+else
+  echo "nvm installation not found at ${NVM_DIR}" >&2
+  exit 1
+fi
+
+if ! nvm ls "${NODE_VERSION}" >/dev/null 2>&1; then
+  log "Installing Node.js ${NODE_VERSION}"
+  nvm install "${NODE_VERSION}"
+fi
+
+log "Activating Node.js ${NODE_VERSION}"
+nvm use "${NODE_VERSION}" >/dev/null
+nvm alias default "${NODE_VERSION}" >/dev/null
+
+if ! grep -q 'source ~/.nvm/nvm.sh' "${HOME}/.bashrc" 2>/dev/null; then
+  echo 'source ~/.nvm/nvm.sh >/dev/null 2>&1' >> "${HOME}/.bashrc"
+fi
+
+# --- Foundry (forge/cast/anvil) ---
+FOUNDRY_BIN="${HOME}/.foundry/bin"
+FOUNDRYUP="${FOUNDRY_BIN}/foundryup"
+
+if ! command -v forge >/dev/null 2>&1; then
+  log "Installing Foundry toolchain"
+  curl -L https://foundry.paradigm.xyz | bash
+fi
+
+if [ -x "${FOUNDRYUP}" ]; then
+  # shellcheck disable=SC1090
+  source "${FOUNDRYUP%/foundryup}/env"
+  log "Running foundryup to ensure latest binaries"
+  "${FOUNDRYUP}" -y >/dev/null
+else
+  echo "foundryup not found at ${FOUNDRYUP}" >&2
+  exit 1
+fi
+
+if ! grep -q 'foundry/bin' "${HOME}/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.foundry/bin:$PATH"' >> "${HOME}/.bashrc"
+fi
+
+log "Setup complete. Open a new shell or run 'source ~/.bashrc' to pick up changes."


### PR DESCRIPTION
## Summary
- Introduces a new `setup.sh` script to automate the installation and setup of Node.js 20 via nvm and the Foundry toolchain
- Updates README to simplify the quick start process by running the setup script instead of manual Foundry installation

## Changes

### Setup Script
- **setup.sh**: New bash script that:
  - Installs nvm (Node Version Manager) if not present
  - Installs and activates Node.js version 20
  - Installs Foundry (forge, cast, anvil) if not already installed
  - Ensures environment variables and PATH are updated in `.bashrc` for persistence
  - Provides clear logging for each step

### Documentation
- **README.md**: Modified quick start instructions to replace manual Foundry install command with `./setup.sh` execution from the repo root

## Test plan
- [x] Run `./setup.sh` on a clean environment and verify Node.js 20 and Foundry are installed and activated
- [x] Confirm that subsequent shell sessions load nvm and Foundry correctly
- [x] Validate README instructions reflect the new setup process
- [x] Run existing tests using Foundry to ensure environment is correctly provisioned

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7867600a-eba6-424d-a29a-8c04c20f65e1