### PR TITLE
fix(pool): enforce oracle divergence guard, optimize fee state loads, and prep gas-saving previews

### DIFF
--- a/hype-usdc-dnmm/CHANGELOG.md
+++ b/hype-usdc-dnmm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## 2025-10-03
+- fix(pool): enforce HyperCore vs Pyth divergence guard for spot quotes using lightweight peek reads, reintroducing `OracleDiverged` fail-closed semantics and aligning perf `DosEconomics` expectations.
+- perf(pool): load fee-state words via a single sload and coalesce settle writes, trimming quote/preview reads without touching feature-flag defaults.
 - perf(pool): cache feature flags as a single word, tighten AOMQ/fee toggles, and lazily read Pyth to shave quote/swap gas while keeping preview paths view-only.
 - fix(rfq): mark inline assembly blocks memory-safe to restore 0.8.24 builds, extend tests for domain caching and ERC1271 fast-path parity.
 - test: add gating scenarios ensuring Pyth adapters are skipped when HyperCore is fresh, preview freshness stays pure, and debug emission obeys flags.

--- a/hype-usdc-dnmm/contracts/CLAUDE.md
+++ b/hype-usdc-dnmm/contracts/CLAUDE.md
@@ -34,6 +34,7 @@
 - Pager/Alert Routing: See `docs/OPERATIONS.md`
 
 ## Change Log
+- 2025-10-02: Tightened HyperCore/Pyth divergence guard for spot quotes via peek-based fallback, restored `DosEconomics` fail-closed expectations, and cached fee state loads to trim quote/preview gas.
 - 2025-10-02: Landed F09 rebates (`setAggregatorDiscount`, capped 3 bps) + pipeline integration and eventing; swap/preview now honor allow-listed discounts without breaching floors.
 - 2025-10-02: Hardened governance (F11) with timelock queue/execute/cancel, pending payload storage, helper label hashes, and `setPauser` for autopause delegations.
 - 2025-10-02: Fixed oracle fail-closed semantics by bubbling `Errors.MidUnset` for both swap/preview and kept `previewFeesFresh` view-only via shared `_readOracleView` helper.


### PR DESCRIPTION
## Summary
- Reintroduces lightweight peek-based fallback for HyperCore vs Pyth oracle divergence guard on spot quotes
- Restores fail-closed `OracleDiverged` semantics with updated divergence rejection logic
- Optimizes fee state management by caching fee-state word with a dedicated `_loadFeeState` helper
- Combines fee state writes via `_writeState` for gas efficiency and state consistency
- Trims quote and preview gas use by consolidating feature flags and minimizing SLOAD operations
- Cleans up oracle data reads to peek Pyth prices when oracle data is empty

## Changes

### Pool Contract (`DnmPool.sol`)
- Added internal `_loadFeeState()` to read packed fee state with a single SLOAD
- Updated fee calculation sites to use `_loadFeeState()` for efficient fee state reads
- Modified oracle divergence checks to:
  - Use peek fallback when oracle data is empty
  - Enforce fail-closed revert on divergence outside soft divergence mode
  - Emit divergence events on debug mode
- Cleaned divergence thresholds logic, removing unnecessary spot mode checks

### Fee Policy Library (`FeePolicy.sol`)
- Introduced `_writeState` private helper to atomically store packed fee state
- Replaced manual field-by-field state update with single storage write for better gas

### Documentation and Changelog
- Updated `CHANGELOG.md` with detailed description of oracle divergence safety fixes and gas optimization improvements
- Adjusted commentary in `CLAUDE.md` to reflect tighter divergence guard and fee state caching

## Test plan
- Existing unit and integration tests extended to cover:
  - Oracle divergence fail-closed behavior
  - Fee preview and settlement consistency
  - Gas measurements to validate improvement
- Added gating scenarios ensuring Pyth adapter skips and preview freshness enforcement

This PR sharpens the tradeoff between gas efficiency, security, and reliability by reintroducing critical oracle divergence protections and streamlining fee state handling.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3b3ebdbd-d3bf-415a-9f06-4c336f9e1a51