### PR TITLE
Add multi-setting benchmark runner with concurrency, Prom metrics, and CSV output

### DIFF
--- a/hype-usdc-dnmm/docs/METRICS_GLOSSARY.md
+++ b/hype-usdc-dnmm/docs/METRICS_GLOSSARY.md
@@ -38,6 +38,24 @@ Name | Type | Labels | Unit | Description | Source
 `dnmm_bbo_spread_bps` | Histogram | `pair,chain,mode` | bps | HyperCore spread. | `shadow-bot/metrics.ts:289`
 `dnmm_fee_bps` | Histogram | `pair,chain,mode,side,rung,regime` | bps | Fee pipeline output. | `shadow-bot/metrics.ts:294`
 `dnmm_total_bps` | Histogram | `pair,chain,mode,side,rung,regime` | bps | Fee minus rebates. | `shadow-bot/metrics.ts:300`
+
+### Multi-run Benchmark Metrics (`shadow.*`)
+Name | Type | Labels | Unit | Description | Source
+--- | --- | --- | --- | --- | ---
+`shadow_mid` | Gauge | `run_id,setting_id,benchmark,pair` | WAD | HyperCore mid used for the latest benchmark tick. | `shadow-bot/src/metrics/multi.ts`
+`shadow_spread_bps` | Gauge | `run_id,setting_id,benchmark,pair` | bps | HyperCore BBO spread passed to adapters. | `shadow-bot/src/metrics/multi.ts`
+`shadow_conf_bps` | Gauge | `run_id,setting_id,benchmark,pair` | bps | Pyth confidence for the tick. | `shadow-bot/src/metrics/multi.ts`
+`shadow_uptime_two_sided_pct` | Gauge | `run_id,setting_id,benchmark,pair` | percent | Rolling two-sided uptime (5 min window). | `shadow-bot/src/metrics/multi.ts`
+`shadow_pnl_quote_cum` | Gauge | `run_id,setting_id,benchmark,pair` | quote units | Cumulative benchmark PnL. | `shadow-bot/src/metrics/multi.ts`
+`shadow_pnl_quote_rate` | Gauge | `run_id,setting_id,benchmark,pair` | quote units/min | PnL rate computed from cumulative PnL. | `shadow-bot/src/metrics/multi.ts`
+`shadow_quotes_total` | Counter | `run_id,setting_id,benchmark,pair,side` | count | Quote samples per side. | `shadow-bot/src/metrics/multi.ts`
+`shadow_trades_total` | Counter | `run_id,setting_id,benchmark,pair` | count | Successful trade executions. | `shadow-bot/src/metrics/multi.ts`
+`shadow_rejects_total` | Counter | `run_id,setting_id,benchmark,pair` | count | Trade intents that failed min-out or liquidity checks. | `shadow-bot/src/metrics/multi.ts`
+`shadow_aomq_clamps_total` | Counter | `run_id,setting_id,benchmark,pair` | count | Trades where AOMQ contributed clamp logic. | `shadow-bot/src/metrics/multi.ts`
+`shadow_recenter_commits_total` | Counter | `run_id,setting_id,benchmark,pair` | count | Recenter events observed in the benchmark loop. | `shadow-bot/src/metrics/multi.ts`
+`shadow_trade_size_base_wad` | Histogram | `run_id,setting_id,benchmark,pair` | WAD | Trade size distribution. | `shadow-bot/src/metrics/multi.ts`
+`shadow_trade_slippage_bps` | Histogram | `run_id,setting_id,benchmark,pair` | bps | Slippage vs HyperCore mid. | `shadow-bot/src/metrics/multi.ts`
+`shadow_quote_latency_ms` | Histogram | `run_id,setting_id,benchmark,pair,side` | milliseconds | Synthetic quote latency per side. | `shadow-bot/src/metrics/multi.ts`
 `dnmm_provider_calls_total` | Counter | `pair,chain,mode,method,result` | count | Oracle RPC successes/failures. | `shadow-bot/metrics.ts:308`
 `dnmm_precompile_errors_total` | Counter | `pair,chain,mode` | count | HyperCore read failures. | `shadow-bot/metrics.ts:318`
 `dnmm_preview_stale_reverts_total` | Counter | `pair,chain,mode` | count | Preview requests that reverted on staleness. | `shadow-bot/metrics.ts:322`

--- a/hype-usdc-dnmm/docs/OBSERVABILITY.md
+++ b/hype-usdc-dnmm/docs/OBSERVABILITY.md
@@ -36,6 +36,27 @@ Metric | Type | Labels | Unit | Description | Source
 `dnmm_quotes_total` | Counter | `pair, chain, mode, result` | count | Quote attempts classified as `ok`, `error`, `fallback`. | `shadow-bot/metrics.ts:334`
 `dnmm_two_sided_uptime_pct` | Gauge | `pair, chain, mode` | percent | Rolling two-sided liquidity uptime over 15 minutes. | `shadow-bot/metrics.ts:340`
 
+### Multi-run (Benchmark) Metrics
+
+When the multi-setting runner is active (`node dist/multi-run.js`), the Prometheus exporter exposes an additional family of `shadow.*` series labelled by `{run_id, setting_id, benchmark, pair}`.
+
+Metric | Type | Labels | Unit | Description | Source
+--- | --- | --- | --- | --- | ---
+`shadow_mid` | Gauge | `run_id, setting_id, benchmark, pair` | WAD | Latest HyperCore mid observed for the benchmark during the tick. | `shadow-bot/src/metrics/multi.ts`
+`shadow_spread_bps` | Gauge | `run_id, setting_id, benchmark, pair` | bps | HyperCore BBO spread forwarded to adapters. | `shadow-bot/src/metrics/multi.ts`
+`shadow_conf_bps` | Gauge | `run_id, setting_id, benchmark, pair` | bps | Pyth confidence captured per tick. | `shadow-bot/src/metrics/multi.ts`
+`shadow_uptime_two_sided_pct` | Gauge | `run_id, setting_id, benchmark, pair` | percent | Rolling 5-minute two-sided uptime for simulated quotes. | `shadow-bot/src/metrics/multi.ts`
+`shadow_pnl_quote_cum` | Gauge | `run_id, setting_id, benchmark, pair` | quote units | Cumulative PnL accrued by the benchmark. | `shadow-bot/src/metrics/multi.ts`
+`shadow_pnl_quote_rate` | Gauge | `run_id, setting_id, benchmark, pair` | quote units/min | PnL run-rate derived from cumulative PnL. | `shadow-bot/src/metrics/multi.ts`
+`shadow_quotes_total` | Counter | `run_id, setting_id, benchmark, pair, side` | count | Quote samples taken (`base_in` / `quote_in`). | `shadow-bot/src/metrics/multi.ts`
+`shadow_trades_total` | Counter | `run_id, setting_id, benchmark, pair` | count | Executed trades where `success=true`. | `shadow-bot/src/metrics/multi.ts`
+`shadow_rejects_total` | Counter | `run_id, setting_id, benchmark, pair` | count | Trade intents rejected (min-out, insufficient liquidity, etc.). | `shadow-bot/src/metrics/multi.ts`
+`shadow_aomq_clamps_total` | Counter | `run_id, setting_id, benchmark, pair` | count | Trades where AOMQ clamp engaged. | `shadow-bot/src/metrics/multi.ts`
+`shadow_recenter_commits_total` | Counter | `run_id, setting_id, benchmark, pair` | count | Placeholder counter for recenter triggers (driver increments when applicable). | `shadow-bot/src/metrics/multi.ts`
+`shadow_trade_size_base_wad` | Histogram | `run_id, setting_id, benchmark, pair` | WAD | Distribution of simulated trade sizes. | `shadow-bot/src/metrics/multi.ts`
+`shadow_trade_slippage_bps` | Histogram | `run_id, setting_id, benchmark, pair` | bps | Observed slippage versus oracle mid. | `shadow-bot/src/metrics/multi.ts`
+`shadow_quote_latency_ms` | Histogram | `run_id, setting_id, benchmark, pair, side` | milliseconds | Synthetic quote latency measurement per side. | `shadow-bot/src/metrics/multi.ts`
+
 ## Derived KPIs
 - `two_sided_uptime_pct` = rolling success rate of quotes returning non-zero liquidity; use `dnmm_two_sided_uptime_pct`.
 - `adverse_selection_bps` = `avg(dnmm_fee_bps)` − `avg(dnmm_total_bps)` when AOMQ inactive; negative swings warrant review of rebates.
@@ -67,4 +88,3 @@ Event | Metrics to Watch | Notes
 `QuoteFilled` (`contracts/quotes/QuoteRFQ.sol:55`) | `dnmm_quotes_total{result="ok"}` | Compare taker fill rate vs pool parity via shadow bot.
 `AggregatorDiscountUpdated` (`contracts/DnmPool.sol:283`) | `dnmm_fee_bps`, `dnmm_total_bps` | Validate discount effect on observed fees.
 `PreviewSnapshotStale` (revert) | `dnmm_preview_stale_reverts_total` | Align with preview config changes.
-

--- a/hype-usdc-dnmm/shadow-bot/CLAUDE.md
+++ b/hype-usdc-dnmm/shadow-bot/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Path**: `hype-usdc-dnmm/shadow-bot`
 
-**Description**: TypeScript multi-setting benchmark harness for HYPE/USDC DNMM, producing concurrent simulations, CSV traces, and Prometheus metrics across DNMM/CPMM/StableSwap comparators.
+**Description**: TypeScript monitoring and simulation suite for the HYPE/USDC DNMM, combining the legacy single-run shadow bot with the new multi-setting benchmark harness (DNMM/CPMM/StableSwap comparators, CSV exports, and Prometheus telemetry).
 
 ## Purpose
 - Capture the intent of this module/folder and its relationship to the broader HYPE/HyperEVM initiative.

--- a/hype-usdc-dnmm/shadow-bot/package-lock.json
+++ b/hype-usdc-dnmm/shadow-bot/package-lock.json
@@ -8,11 +8,21 @@
       "name": "dnmm-shadow-bot",
       "version": "2.0.0",
       "dependencies": {
+        "cross-spawn": "^7.0.3",
         "csv-parse": "^5.5.0",
         "dotenv": "^16.4.5",
         "ethers": "^6.15.0",
+        "execa": "^5.1.1",
+        "isexe": "^1.1.2",
+        "merge-stream": "^1.0.1",
         "node-fetch": "^3.3.2",
-        "prom-client": "^15.1.1"
+        "path-key": "^2.0.1",
+        "picocolors": "^1.0.0",
+        "prom-client": "^15.1.1",
+        "shebang-command": "^1.2.0",
+        "signal-exit": "^3.0.7",
+        "tinypool": "^0.2.4",
+        "which": "^1.3.1"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -20,7 +30,7 @@
         "rimraf": "^5.0.7",
         "ts-node": "^10.9.2",
         "typescript": "5.6.3",
-        "vitest": "^1.2.2"
+        "vitest": "1.2.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -540,9 +550,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
-      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
       "cpu": [
         "arm"
       ],
@@ -554,9 +564,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
-      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
       "cpu": [
         "arm64"
       ],
@@ -568,9 +578,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
-      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
       "cpu": [
         "arm64"
       ],
@@ -582,9 +592,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
-      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
       "cpu": [
         "x64"
       ],
@@ -596,9 +606,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
-      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
       "cpu": [
         "arm64"
       ],
@@ -610,9 +620,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
-      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
       "cpu": [
         "x64"
       ],
@@ -624,9 +634,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
-      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
       "cpu": [
         "arm"
       ],
@@ -638,9 +648,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
-      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
       "cpu": [
         "arm"
       ],
@@ -652,9 +662,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
-      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
       "cpu": [
         "arm64"
       ],
@@ -666,9 +676,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
-      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
       "cpu": [
         "arm64"
       ],
@@ -680,9 +690,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
-      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
       "cpu": [
         "loong64"
       ],
@@ -694,9 +704,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
-      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
       "cpu": [
         "ppc64"
       ],
@@ -708,9 +718,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
-      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
       "cpu": [
         "riscv64"
       ],
@@ -722,9 +732,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
-      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
       "cpu": [
         "riscv64"
       ],
@@ -736,9 +746,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
-      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
       "cpu": [
         "s390x"
       ],
@@ -750,9 +760,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
-      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
       "cpu": [
         "x64"
       ],
@@ -764,9 +774,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
-      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
       "cpu": [
         "x64"
       ],
@@ -778,9 +788,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
-      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
       "cpu": [
         "arm64"
       ],
@@ -792,9 +802,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
-      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
       "cpu": [
         "arm64"
       ],
@@ -806,9 +816,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
-      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
       "cpu": [
         "ia32"
       ],
@@ -820,9 +830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
-      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
       "cpu": [
         "x64"
       ],
@@ -834,9 +844,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
-      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
       "cpu": [
         "x64"
       ],
@@ -900,14 +910,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.2.2.tgz",
+      "integrity": "sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -915,13 +925,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.2.2.tgz",
+      "integrity": "sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.1",
+        "@vitest/utils": "1.2.2",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -930,9 +940,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.2.2.tgz",
+      "integrity": "sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -945,9 +955,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.2.tgz",
+      "integrity": "sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -958,9 +968,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.2.2.tgz",
+      "integrity": "sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1213,6 +1223,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1221,15 +1237,65 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -1420,28 +1486,33 @@
       "license": "MIT"
     },
     "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/execa/node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -1496,6 +1567,90 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1534,13 +1689,12 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1617,13 +1771,12 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/ignore-by-default": {
@@ -1631,6 +1784,12 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -1690,23 +1849,27 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw==",
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -1724,13 +1887,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
@@ -1784,23 +1940,21 @@
       "license": "ISC"
     },
     "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
     },
     "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -1950,45 +2104,36 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "license": "MIT",
       "dependencies": {
-        "path-key": "^4.0.0"
+        "path-key": "^3.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^4.0.0"
+        "mimic-fn": "^2.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2018,13 +2163,12 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/path-scurry": {
@@ -2062,10 +2206,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2129,6 +2272,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -2143,6 +2293,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prom-client": {
       "version": "15.1.3",
@@ -2170,6 +2326,21 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2201,9 +2372,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
-      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2217,30 +2388,36 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.3",
-        "@rollup/rollup-android-arm64": "4.52.3",
-        "@rollup/rollup-darwin-arm64": "4.52.3",
-        "@rollup/rollup-darwin-x64": "4.52.3",
-        "@rollup/rollup-freebsd-arm64": "4.52.3",
-        "@rollup/rollup-freebsd-x64": "4.52.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
-        "@rollup/rollup-linux-arm64-musl": "4.52.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
-        "@rollup/rollup-linux-x64-gnu": "4.52.3",
-        "@rollup/rollup-linux-x64-musl": "4.52.3",
-        "@rollup/rollup-openharmony-arm64": "4.52.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
-        "@rollup/rollup-win32-x64-gnu": "4.52.3",
-        "@rollup/rollup-win32-x64-msvc": "4.52.3",
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -2256,26 +2433,24 @@
       }
     },
     "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "license": "MIT",
       "dependencies": {
-        "shebang-regex": "^3.0.0"
+        "shebang-regex": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/siginfo": {
@@ -2286,17 +2461,10 @@
       "license": "ISC"
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -2334,6 +2502,15 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -2440,26 +2617,22 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/strip-literal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "js-tokens": "^9.0.1"
+        "acorn": "^8.10.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2495,10 +2668,9 @@
       "license": "MIT"
     },
     "node_modules/tinypool": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
-      "dev": true,
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.2.4.tgz",
+      "integrity": "sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2632,6 +2804,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -2700,9 +2878,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.2.2.tgz",
+      "integrity": "sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2723,18 +2901,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.2.tgz",
+      "integrity": "sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.1",
-        "@vitest/runner": "1.6.1",
-        "@vitest/snapshot": "1.6.1",
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
+        "@vitest/expect": "1.2.2",
+        "@vitest/runner": "1.2.2",
+        "@vitest/snapshot": "1.2.2",
+        "@vitest/spy": "1.2.2",
+        "@vitest/utils": "1.2.2",
         "acorn-walk": "^8.3.2",
+        "cac": "^6.7.14",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "execa": "^8.0.1",
@@ -2743,11 +2922,11 @@
         "pathe": "^1.1.1",
         "picocolors": "^1.0.0",
         "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
+        "strip-literal": "^1.3.0",
         "tinybench": "^2.5.1",
-        "tinypool": "^0.8.3",
+        "tinypool": "^0.8.2",
         "vite": "^5.0.0",
-        "vite-node": "1.6.1",
+        "vite-node": "1.2.2",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -2762,8 +2941,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.1",
-        "@vitest/ui": "1.6.1",
+        "@vitest/browser": "^1.0.0",
+        "@vitest/ui": "^1.0.0",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -2788,6 +2967,167 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vitest/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/vitest/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vitest/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -2798,20 +3138,22 @@
       }
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
+        "which": "bin/which"
       }
+    },
+    "node_modules/which/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/hype-usdc-dnmm/shadow-bot/package.json
+++ b/hype-usdc-dnmm/shadow-bot/package.json
@@ -16,11 +16,21 @@
     "clean": "rimraf dist && rimraf metrics/hype-metrics && rimraf reports"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.3",
     "csv-parse": "^5.5.0",
     "dotenv": "^16.4.5",
     "ethers": "^6.15.0",
+    "execa": "^5.1.1",
+    "isexe": "^1.1.2",
+    "merge-stream": "^1.0.1",
     "node-fetch": "^3.3.2",
-    "prom-client": "^15.1.1"
+    "path-key": "^2.0.1",
+    "picocolors": "^1.0.0",
+    "prom-client": "^15.1.1",
+    "shebang-command": "^1.2.0",
+    "signal-exit": "^3.0.7",
+    "tinypool": "^0.2.4",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -28,7 +38,7 @@
     "rimraf": "^5.0.7",
     "ts-node": "^10.9.2",
     "typescript": "5.6.3",
-    "vitest": "^1.2.2"
+    "vitest": "1.2.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/hype-usdc-dnmm/shadow-bot/settings/hype_settings.json
+++ b/hype-usdc-dnmm/shadow-bot/settings/hype_settings.json
@@ -1,0 +1,107 @@
+{
+  "version": "1",
+  "pair": "HYPE/USDC",
+  "runs": [
+    {
+      "id": "A",
+      "label": "baseline_calm",
+      "featureFlags": {
+        "enableSoftDivergence": true,
+        "enableSizeFee": false,
+        "enableBboFloor": true,
+        "enableInvTilt": true,
+        "enableAOMQ": false,
+        "enableRebates": false
+      },
+      "makerParams": {
+        "betaFloorBps": 15,
+        "alphaBboBps": 2500,
+        "S0Notional": 10000
+      },
+      "inventoryParams": {
+        "invTiltBpsPer1pct": 100,
+        "invTiltMaxBps": 150,
+        "tiltConfWeightBps": 4000,
+        "tiltSpreadWeightBps": 4000
+      },
+      "aomqParams": {
+        "minQuoteNotional": 200,
+        "emergencySpreadBps": 120,
+        "floorEpsilonBps": 200
+      },
+      "flow": {
+        "pattern": "benign_poisson",
+        "seconds": 600,
+        "seed": 42,
+        "txn_rate_per_min": 20,
+        "size_dist": "lognormal",
+        "size_params": {
+          "mu": 0,
+          "sigma": 0.9,
+          "min": 50,
+          "max": 2500
+        }
+      },
+      "latency": {
+        "quote_to_tx_ms": 250,
+        "jitter_ms": 50
+      },
+      "router": {
+        "slippage_bps": 30,
+        "ttl_sec": 20,
+        "minOut_policy": "preview"
+      }
+    },
+    {
+      "id": "B",
+      "label": "size_fee_active",
+      "featureFlags": {
+        "enableSoftDivergence": true,
+        "enableSizeFee": true,
+        "enableBboFloor": true,
+        "enableInvTilt": true,
+        "enableAOMQ": false,
+        "enableRebates": false
+      },
+      "makerParams": {
+        "betaFloorBps": 15,
+        "alphaBboBps": 3000,
+        "S0Notional": 15000
+      },
+      "inventoryParams": {
+        "invTiltBpsPer1pct": 120,
+        "invTiltMaxBps": 200,
+        "tiltConfWeightBps": 5000,
+        "tiltSpreadWeightBps": 5000
+      },
+      "aomqParams": {
+        "minQuoteNotional": 300,
+        "emergencySpreadBps": 150,
+        "floorEpsilonBps": 200
+      },
+      "flow": {
+        "pattern": "trend",
+        "seconds": 600,
+        "seed": 43,
+        "txn_rate_per_min": 18,
+        "size_dist": "lognormal",
+        "size_params": {
+          "mu": 0.2,
+          "sigma": 1.1,
+          "min": 50,
+          "max": 5000
+        }
+      },
+      "latency": {
+        "quote_to_tx_ms": 300,
+        "jitter_ms": 60
+      },
+      "router": {
+        "slippage_bps": 25,
+        "ttl_sec": 20,
+        "minOut_policy": "preview_ladder"
+      }
+    }
+  ],
+  "benchmarks": ["dnmm", "cpmm", "stableswap"]
+}

--- a/hype-usdc-dnmm/shadow-bot/src/benchmarks/CLAUDE.md
+++ b/hype-usdc-dnmm/shadow-bot/src/benchmarks/CLAUDE.md
@@ -1,6 +1,6 @@
 # Shadow Bot Benchmarks Implementation Guide
 
-**Path**: `hype-usdc-dnmm/shadow-bot/benchmarks`
+**Path**: `hype-usdc-dnmm/shadow-bot/src/benchmarks`
 
 **Description**: Adapters that emulate DNMM and baseline AMMs (CPMM, StableSwap-like) for comparative simulations and scoring.
 

--- a/hype-usdc-dnmm/shadow-bot/src/benchmarks/cpmm.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/benchmarks/cpmm.ts
@@ -44,14 +44,6 @@ export class CpmmBenchmarkAdapter implements BenchmarkAdapter {
     // deterministic emulator – no external resources
   }
 
-  async init(): Promise<void> {
-    // no-op for deterministic emulator
-  }
-
-  async close(): Promise<void> {
-    // no-op
-  }
-
   async prepareTick(context: BenchmarkTickContext): Promise<void> {
     this.lastOracle = context.oracle;
     const mid = context.oracle.hc.midWad;

--- a/hype-usdc-dnmm/shadow-bot/src/benchmarks/dnmm.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/benchmarks/dnmm.ts
@@ -41,7 +41,7 @@ export class DnmmBenchmarkAdapter implements BenchmarkAdapter {
   }
 
   async close(): Promise<void> {
-    // no-op
+    // adapters do not hold external resources currently
   }
 
   async prepareTick(context: BenchmarkTickContext): Promise<void> {

--- a/hype-usdc-dnmm/shadow-bot/src/config-multi.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/config-multi.ts
@@ -1,0 +1,541 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  BENCHMARK_IDS,
+  BenchmarkId,
+  FlowPatternConfig,
+  FlowPatternId,
+  FlowSizeDistribution,
+  FlowSizeDistributionKind,
+  FlowToxicityConfig,
+  LatencyProfile,
+  MultiRunRuntimeConfig,
+  RunAomqParams,
+  RunFeatureFlags,
+  RunInventoryParams,
+  RunMakerParams,
+  RunSettingDefinition,
+  RunnerPaths,
+  SettingsFileSchema,
+  ShadowBotConfig,
+  RouterConfig,
+  isChainBackedConfig,
+  RuntimeChainConfig,
+  ChainRuntimeConfig,
+  MockRuntimeConfig,
+  ChainBackedConfig,
+  MockShadowBotConfig
+} from './types.js';
+import { loadConfig } from './config.js';
+
+interface CliOptions {
+  readonly runId?: string;
+  readonly settingsPath?: string;
+  readonly durationSec?: number;
+  readonly maxParallel?: number;
+  readonly seedBase?: number;
+  readonly benchmarks?: string[];
+  readonly persistCsv?: boolean;
+  readonly promPort?: number;
+  readonly logLevel?: 'info' | 'debug';
+  readonly runRoot?: string;
+}
+
+const DEFAULT_SETTINGS_PATH = path.resolve(process.cwd(), 'settings/hype_settings.json');
+const DEFAULT_METRICS_ROOT = path.resolve(process.cwd(), 'metrics/hype-metrics');
+const DEFAULT_MAX_PARALLEL = 6;
+const DEFAULT_SEED_BASE = 1_337;
+
+export async function loadMultiRunConfig(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env
+): Promise<MultiRunRuntimeConfig> {
+  const cli = parseCliOptions(argv);
+  const baseConfig = await loadConfig();
+
+  const runId = sanitizeRunId(cli.runId ?? env.RUN_ID ?? defaultRunId());
+  const settingsPath = path.resolve(
+    cli.settingsPath ?? env.SETTINGS_FILE ?? DEFAULT_SETTINGS_PATH
+  );
+  const settings = await loadSettingsFile(settingsPath);
+  const runs = settings.runs.map((run, index) => normalizeRunSetting(run, index));
+  ensureUniqueRunIds(runs);
+
+  const benchmarks = resolveBenchmarks(
+    cli.benchmarks ?? parseBenchmarksEnv(env.BENCHMARKS),
+    settings.benchmarks
+  );
+
+  let chainConfig: ChainBackedConfig | undefined;
+  let mockConfig: MockShadowBotConfig | undefined;
+  if (isChainBackedConfig(baseConfig)) {
+    chainConfig = baseConfig;
+  } else {
+    mockConfig = baseConfig;
+  }
+
+  const promPort = cli.promPort ?? parseOptionalInt(env.PROM_PORT) ?? baseConfig.promPort;
+  const maxParallel = cli.maxParallel ?? parseOptionalInt(env.MAX_PARALLEL) ?? DEFAULT_MAX_PARALLEL;
+  const seedBase = cli.seedBase ?? parseOptionalInt(env.SEED_BASE) ?? DEFAULT_SEED_BASE;
+  const durationOverrideSec = cli.durationSec ?? parseOptionalInt(env.DURATION_SEC);
+  const persistCsv = cli.persistCsv ?? parseOptionalBoolean(env.PERSIST_CSV) ?? true;
+  const logLevel = cli.logLevel ?? parseLogLevel(env.LOG_LEVEL) ?? baseConfig.logLevel;
+
+  const metricsRoot = path.resolve(
+    cli.runRoot ?? env.METRICS_ROOT ?? DEFAULT_METRICS_ROOT
+  );
+  const paths = buildRunnerPaths(metricsRoot, runId);
+
+  const runtime = extractRuntime(baseConfig);
+
+  return {
+    runId,
+    baseConfig,
+    chainConfig,
+    mockConfig,
+    logLevel,
+    benchmarks,
+    maxParallel,
+    persistCsv,
+    promPort,
+    seedBase,
+    durationOverrideSec,
+    pairLabels: baseConfig.labels,
+    settings,
+    runs,
+    paths,
+    runtime,
+    addressBookPath: isChainBackedConfig(baseConfig) ? baseConfig.addressBookSource : undefined
+  };
+}
+
+function parseCliOptions(argv: readonly string[]): CliOptions {
+  const options: Record<string, unknown> = {};
+  let index = 0;
+  while (index < argv.length) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      index += 1;
+      continue;
+    }
+    const [flag, valuePart] = arg.split('=');
+    const key = flag.slice(2);
+    let value: string | undefined = valuePart;
+    if (!value && index + 1 < argv.length && !argv[index + 1].startsWith('--')) {
+      value = argv[index + 1];
+      index += 1;
+    }
+    switch (key) {
+      case 'run-id':
+        options.runId = value;
+        break;
+      case 'settings':
+        options.settingsPath = value;
+        break;
+      case 'duration-sec':
+        options.durationSec = value ? parseIntStrict(value, 'duration-sec') : undefined;
+        break;
+      case 'max-parallel':
+        options.maxParallel = value ? parseIntStrict(value, 'max-parallel') : undefined;
+        break;
+      case 'seed-base':
+        options.seedBase = value ? parseIntStrict(value, 'seed-base') : undefined;
+        break;
+      case 'benchmarks':
+        options.benchmarks = value
+          ? value.split(',').map((entry) => entry.trim()).filter(Boolean)
+          : [];
+        break;
+      case 'persist-csv':
+        options.persistCsv = value ? parseBoolean(value) : true;
+        break;
+      case 'no-persist-csv':
+        options.persistCsv = false;
+        break;
+      case 'prom-port':
+        options.promPort = value ? parseIntStrict(value, 'prom-port') : undefined;
+        break;
+      case 'log-level':
+        options.logLevel = parseLogLevel(value);
+        break;
+      case 'run-root':
+        options.runRoot = value;
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  return options as CliOptions;
+}
+
+async function loadSettingsFile(settingsPath: string): Promise<SettingsFileSchema> {
+  try {
+    const contents = await fs.readFile(settingsPath, 'utf8');
+    const parsed = JSON.parse(contents) as SettingsFileSchema;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.runs)) {
+      throw new Error('settings file must contain a non-empty runs array');
+    }
+    if (parsed.runs.length === 0) {
+      throw new Error('settings file has empty runs array');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to load settings file at ${settingsPath}: ${(error as Error).message}`);
+  }
+}
+
+function resolveBenchmarks(
+  cli: string[] | undefined,
+  fromSettings: readonly string[] | undefined
+): BenchmarkId[] {
+  const source = cli && cli.length > 0 ? cli : fromSettings ?? [];
+  if (source.length === 0) {
+    return ['dnmm'];
+  }
+  return source.map((entry) => {
+    const normalized = entry.toLowerCase() as BenchmarkId;
+    if (!BENCHMARK_IDS.includes(normalized)) {
+      throw new Error(`Unsupported benchmark: ${entry}`);
+    }
+    return normalized;
+  });
+}
+
+function buildRunnerPaths(root: string, runId: string): RunnerPaths {
+  const runRoot = path.join(root, `run_${runId}`);
+  return {
+    runRoot,
+    tradesDir: path.join(runRoot, 'trades'),
+    quotesDir: path.join(runRoot, 'quotes'),
+    scoreboardPath: path.join(runRoot, 'scoreboard.csv')
+  };
+}
+
+function ensureUniqueRunIds(runs: readonly RunSettingDefinition[]): void {
+  const ids = new Set<string>();
+  for (const run of runs) {
+    if (ids.has(run.id)) {
+      throw new Error(`Duplicate run id detected: ${run.id}`);
+    }
+    ids.add(run.id);
+  }
+}
+
+function normalizeRunSetting(raw: unknown, index: number): RunSettingDefinition {
+  const record = expectRecord(raw, `runs[${index}]`);
+  const id = requireString(record.id, `runs[${index}].id`);
+  const label = requireString(record.label, `runs[${index}].label`);
+  const featureFlags = normalizeFeatureFlags(record.featureFlags, index);
+  const makerParams = normalizeMakerParams(record.makerParams, index);
+  const inventoryParams = normalizeInventoryParams(record.inventoryParams, index);
+  const aomqParams = normalizeAomqParams(record.aomqParams, index);
+  const flow = normalizeFlow(record.flow, index);
+  const latency = normalizeLatency(record.latency, index);
+  const router = normalizeRouter(record.router, index);
+  return {
+    id,
+    label,
+    featureFlags,
+    makerParams,
+    inventoryParams,
+    aomqParams,
+    flow,
+    latency,
+    router
+  };
+}
+
+function normalizeFeatureFlags(raw: unknown, index: number): RunFeatureFlags {
+  const record = expectRecord(raw, `runs[${index}].featureFlags`);
+  return {
+    enableSoftDivergence: parseBoolean(record.enableSoftDivergence ?? true),
+    enableSizeFee: parseBoolean(record.enableSizeFee ?? false),
+    enableBboFloor: parseBoolean(record.enableBboFloor ?? true),
+    enableInvTilt: parseBoolean(record.enableInvTilt ?? true),
+    enableAOMQ: parseBoolean(record.enableAOMQ ?? false),
+    enableRebates: parseBoolean(record.enableRebates ?? false)
+  };
+}
+
+function normalizeMakerParams(raw: unknown, index: number): RunMakerParams {
+  const record = expectRecord(raw, `runs[${index}].makerParams`);
+  return {
+    betaFloorBps: toNumber(record.betaFloorBps, `runs[${index}].makerParams.betaFloorBps`),
+    alphaBboBps: toNumber(record.alphaBboBps, `runs[${index}].makerParams.alphaBboBps`),
+    S0Notional: toNumber(
+      record.S0Notional ?? record.s0Notional,
+      `runs[${index}].makerParams.S0Notional`
+    )
+  };
+}
+
+function normalizeInventoryParams(raw: unknown, index: number): RunInventoryParams {
+  const record = expectRecord(raw, `runs[${index}].inventoryParams`);
+  return {
+    invTiltBpsPer1pct: toNumber(
+      record.invTiltBpsPer1pct,
+      `runs[${index}].inventoryParams.invTiltBpsPer1pct`
+    ),
+    invTiltMaxBps: toNumber(
+      record.invTiltMaxBps,
+      `runs[${index}].inventoryParams.invTiltMaxBps`
+    ),
+    tiltConfWeightBps: toNumber(
+      record.tiltConfWeightBps,
+      `runs[${index}].inventoryParams.tiltConfWeightBps`
+    ),
+    tiltSpreadWeightBps: toNumber(
+      record.tiltSpreadWeightBps,
+      `runs[${index}].inventoryParams.tiltSpreadWeightBps`
+    )
+  };
+}
+
+function normalizeAomqParams(raw: unknown, index: number): RunAomqParams {
+  const record = expectRecord(raw, `runs[${index}].aomqParams`);
+  return {
+    minQuoteNotional: toNumber(
+      record.minQuoteNotional,
+      `runs[${index}].aomqParams.minQuoteNotional`
+    ),
+    emergencySpreadBps: toNumber(
+      record.emergencySpreadBps,
+      `runs[${index}].aomqParams.emergencySpreadBps`
+    ),
+    floorEpsilonBps: toNumber(
+      record.floorEpsilonBps,
+      `runs[${index}].aomqParams.floorEpsilonBps`
+    )
+  };
+}
+
+function normalizeFlow(raw: unknown, index: number): FlowPatternConfig {
+  const record = expectRecord(raw, `runs[${index}].flow`);
+  const patternRaw = requireString(record.pattern, `runs[${index}].flow.pattern`).toLowerCase();
+  if (!isFlowPattern(patternRaw)) {
+    throw new Error(`Unsupported flow pattern: ${patternRaw}`);
+  }
+  const seconds = toNumber(record.seconds, `runs[${index}].flow.seconds`);
+  const seed = toNumber(record.seed, `runs[${index}].flow.seed`);
+  const txnRatePerMin = toNumber(
+    record.txn_rate_per_min ?? record.txnRatePerMin,
+    `runs[${index}].flow.txn_rate_per_min`
+  );
+  const sizeKind = (record.size_dist ?? record.sizeDist ?? 'lognormal') as FlowSizeDistributionKind;
+  const size = normalizeFlowSize(sizeKind, record.size_params ?? record.sizeParams, index);
+  const toxicity = record.toxicity ? normalizeToxicity(record.toxicity, index) : undefined;
+  return {
+    pattern: patternRaw,
+    seconds,
+    seed,
+    txnRatePerMin,
+    size,
+    toxicity
+  };
+}
+
+function normalizeFlowSize(
+  kindRaw: FlowSizeDistributionKind,
+  paramsRaw: unknown,
+  index: number
+): FlowSizeDistribution {
+  const kind = (kindRaw ?? 'lognormal').toLowerCase() as FlowSizeDistributionKind;
+  const params = expectRecord(paramsRaw, `runs[${index}].flow.size_params`);
+  const min = toNumber(params.min, `runs[${index}].flow.size_params.min`);
+  const max = toNumber(params.max ?? params.min, `runs[${index}].flow.size_params.max`);
+  if (kind === 'lognormal') {
+    return {
+      kind,
+      mu: toNumber(params.mu, `runs[${index}].flow.size_params.mu`),
+      sigma: toNumber(params.sigma, `runs[${index}].flow.size_params.sigma`),
+      min,
+      max
+    };
+  }
+  if (kind === 'pareto') {
+    return {
+      kind,
+      mu: toNumber(params.mu, `runs[${index}].flow.size_params.mu`),
+      sigma: toNumber(
+        params.sigma ?? params.alpha ?? 1,
+        `runs[${index}].flow.size_params.sigma`
+      ),
+      min,
+      max
+    };
+  }
+  if (kind === 'fixed') {
+    return {
+      kind,
+      min,
+      max
+    };
+  }
+  throw new Error(`Unsupported size distribution: ${kind}`);
+}
+
+function normalizeToxicity(raw: unknown, index: number): FlowToxicityConfig {
+  const record = expectRecord(raw, `runs[${index}].flow.toxicity`);
+  return {
+    oracleLeadMs: toNumber(
+      record.oracle_lead_ms ?? record.oracleLeadMs,
+      `runs[${index}].flow.toxicity.oracle_lead_ms`
+    ),
+    edgeBpsMu: toNumber(
+      record.edge_bps_mu ?? record.edgeBpsMu,
+      `runs[${index}].flow.toxicity.edge_bps_mu`
+    ),
+    edgeBpsSigma: toNumber(
+      record.edge_bps_sigma ?? record.edgeBpsSigma,
+      `runs[${index}].flow.toxicity.edge_bps_sigma`
+    )
+  };
+}
+
+function normalizeLatency(raw: unknown, index: number): LatencyProfile {
+  const record = expectRecord(raw, `runs[${index}].latency`);
+  return {
+    quoteToTxMs: toNumber(
+      record.quote_to_tx_ms ?? record.quoteToTxMs,
+      `runs[${index}].latency.quote_to_tx_ms`
+    ),
+    jitterMs: toNumber(record.jitter_ms ?? record.jitterMs, `runs[${index}].latency.jitter_ms`)
+  };
+}
+
+function normalizeRouter(raw: unknown, index: number): RouterConfig {
+  const record = expectRecord(raw, `runs[${index}].router`);
+  const policyRaw = requireString(
+    record.minOut_policy ?? record.minOutPolicy,
+    `runs[${index}].router.minOut_policy`
+  ).toLowerCase();
+  if (!['preview', 'preview_ladder', 'fixed_margin'].includes(policyRaw)) {
+    throw new Error(`Unsupported router policy: ${policyRaw}`);
+  }
+  return {
+    slippageBps: toNumber(
+      record.slippage_bps ?? record.slippageBps,
+      `runs[${index}].router.slippage_bps`
+    ),
+    ttlSec: toNumber(record.ttl_sec ?? record.ttlSec, `runs[${index}].router.ttl_sec`),
+    minOutPolicy: policyRaw as RouterConfig['minOutPolicy']
+  };
+}
+
+function extractRuntime(config: ShadowBotConfig): RuntimeChainConfig {
+  if (isChainBackedConfig(config)) {
+    const chain: ChainRuntimeConfig = {
+      mode: config.mode,
+      rpcUrl: config.rpcUrl,
+      wsUrl: config.wsUrl,
+      chainId: config.chainId,
+      poolAddress: config.poolAddress,
+      baseTokenAddress: config.baseTokenAddress,
+      quoteTokenAddress: config.quoteTokenAddress,
+      baseDecimals: config.baseDecimals,
+      quoteDecimals: config.quoteDecimals,
+      pythAddress: config.pythAddress,
+      hcPxPrecompile: config.hcPxPrecompile,
+      hcBboPrecompile: config.hcBboPrecompile,
+      hcPxKey: config.hcPxKey,
+      hcBboKey: config.hcBboKey,
+      hcMarketType: config.hcMarketType,
+      hcSizeDecimals: config.hcSizeDecimals,
+      hcPxMultiplier: config.hcPxMultiplier,
+      pythPriceId: config.pythPriceId,
+      gasPriceGwei: config.gasPriceGwei,
+      nativeUsd: config.nativeUsd,
+      addressBookSource: config.addressBookSource
+    };
+    return chain;
+  }
+  const mock: MockRuntimeConfig = { mode: 'mock' };
+  return mock;
+}
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  throw new Error(`${label} must be a non-empty string`);
+}
+
+function toNumber(value: unknown, label: string): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const normalized = value.replace(/_/g, '');
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  throw new Error(`${label} must be numeric`);
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return false;
+  const lowered = value.toLowerCase();
+  return lowered === 'true' || lowered === '1' || lowered === 'yes';
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  return parseBoolean(value);
+}
+
+function parseOptionalInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function parseIntStrict(value: string, label: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Unable to parse integer for ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function parseLogLevel(raw?: string | null): 'info' | 'debug' | undefined {
+  if (!raw) return undefined;
+  return raw.toLowerCase() === 'debug' ? 'debug' : 'info';
+}
+
+function parseBenchmarksEnv(raw?: string): string[] | undefined {
+  if (!raw) return undefined;
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function sanitizeRunId(runId: string): string {
+  return runId.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function defaultRunId(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function isFlowPattern(value: string): value is FlowPatternId {
+  return (
+    value === 'arb_constant' ||
+    value === 'toxic' ||
+    value === 'trend' ||
+    value === 'mean_revert' ||
+    value === 'benign_poisson' ||
+    value === 'mixed'
+  );
+}

--- a/hype-usdc-dnmm/shadow-bot/src/csv/multiWriter.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/csv/multiWriter.ts
@@ -1,0 +1,168 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { MultiRunRuntimeConfig, QuoteCsvRecord, ScoreboardRow, TradeCsvRecord } from '../types.js';
+
+const TRADE_HEADER = [
+  'ts_iso',
+  'setting_id',
+  'benchmark',
+  'side',
+  'amount_in',
+  'amount_out',
+  'mid_used',
+  'fee_bps_used',
+  'floor_bps',
+  'tilt_bps',
+  'aomq_clamped',
+  'minOut',
+  'slippage_bps_vs_mid',
+  'pnl_quote',
+  'inventory_base',
+  'inventory_quote'
+];
+
+const QUOTE_HEADER = [
+  'ts_iso',
+  'setting_id',
+  'benchmark',
+  'side',
+  'size_base_wad',
+  'fee_bps',
+  'mid',
+  'spread_bps',
+  'conf_bps',
+  'aomq_active'
+];
+
+const SCOREBOARD_HEADER = [
+  'setting_id',
+  'benchmark',
+  'trades',
+  'pnl_quote_total',
+  'pnl_per_mm_notional_bps',
+  'win_rate_pct',
+  'avg_fee_bps',
+  'avg_slippage_bps',
+  'two_sided_uptime_pct',
+  'reject_rate_pct',
+  'aomq_clamps_total',
+  'recenter_commits_total'
+];
+
+export interface MultiCsvWriter {
+  init(): Promise<void>;
+  appendTrades(records: readonly TradeCsvRecord[]): Promise<void>;
+  appendQuotes(records: readonly QuoteCsvRecord[]): Promise<void>;
+  writeScoreboard(rows: readonly ScoreboardRow[]): Promise<void>;
+  close(): Promise<void>;
+}
+
+export function createMultiCsvWriter(config: MultiRunRuntimeConfig): MultiCsvWriter {
+  const headerCache = new Set<string>();
+  const tradesDir = config.paths.tradesDir;
+  const quotesDir = config.paths.quotesDir;
+  const scoreboardPath = config.paths.scoreboardPath;
+  const persist = config.persistCsv;
+
+  return {
+    async init(): Promise<void> {
+      if (!persist) return;
+      await fs.mkdir(tradesDir, { recursive: true });
+      await fs.mkdir(quotesDir, { recursive: true });
+    },
+    async appendTrades(records: readonly TradeCsvRecord[]): Promise<void> {
+      if (!persist || records.length === 0) return;
+      await Promise.all(
+        records.map((record) =>
+          appendRow(tradesDir, record.settingId, record.benchmark, TRADE_HEADER, tradeRow(record), headerCache)
+        )
+      );
+    },
+    async appendQuotes(records: readonly QuoteCsvRecord[]): Promise<void> {
+      if (!persist || records.length === 0) return;
+      await Promise.all(
+        records.map((record) =>
+          appendRow(quotesDir, record.settingId, record.benchmark, QUOTE_HEADER, quoteRow(record), headerCache)
+        )
+      );
+    },
+    async writeScoreboard(rows: readonly ScoreboardRow[]): Promise<void> {
+      const content = [SCOREBOARD_HEADER.join(','), ...rows.map(scoreboardRow)].join('\n');
+      await fs.mkdir(path.dirname(scoreboardPath), { recursive: true });
+      await fs.writeFile(scoreboardPath, `${content}\n`, 'utf8');
+    },
+    async close(): Promise<void> {
+      // no resources to release
+    }
+  };
+}
+
+async function appendRow(
+  directory: string,
+  settingId: string,
+  benchmark: string,
+  header: readonly string[],
+  row: string,
+  cache: Set<string>
+): Promise<void> {
+  const filePath = path.join(directory, `${settingId}_${benchmark}.csv`);
+  if (!cache.has(filePath)) {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, `${header.join(',')}\n`, { flag: 'w' });
+    cache.add(filePath);
+  }
+  await fs.appendFile(filePath, `${row}\n`);
+}
+
+function tradeRow(record: TradeCsvRecord): string {
+  return [
+    record.tsIso,
+    record.settingId,
+    record.benchmark,
+    record.side,
+    record.amountIn,
+    record.amountOut,
+    record.midUsed,
+    String(record.feeBpsUsed),
+    record.floorBps !== undefined ? String(record.floorBps) : '',
+    record.tiltBps !== undefined ? String(record.tiltBps) : '',
+    record.aomqClamped ? 'true' : 'false',
+    record.minOut ?? '',
+    record.slippageBpsVsMid.toFixed(6),
+    record.pnlQuote.toFixed(6),
+    record.inventoryBase,
+    record.inventoryQuote
+  ].join(',');
+}
+
+function quoteRow(record: QuoteCsvRecord): string {
+  return [
+    record.tsIso,
+    record.settingId,
+    record.benchmark,
+    record.side,
+    record.sizeBaseWad,
+    String(record.feeBps),
+    record.mid,
+    String(record.spreadBps),
+    record.confBps !== undefined ? String(record.confBps) : '',
+    record.aomqActive ? 'true' : 'false'
+  ].join(',');
+}
+
+function scoreboardRow(row: ScoreboardRow): string {
+  return [
+    row.settingId,
+    row.benchmark,
+    String(row.trades),
+    row.pnlQuoteTotal.toFixed(6),
+    row.pnlPerMmNotionalBps.toFixed(6),
+    row.winRatePct.toFixed(4),
+    row.avgFeeBps.toFixed(4),
+    row.avgSlippageBps.toFixed(4),
+    row.twoSidedUptimePct.toFixed(4),
+    row.rejectRatePct.toFixed(4),
+    String(row.aomqClampsTotal),
+    String(row.recenterCommitsTotal)
+  ].join(',');
+}

--- a/hype-usdc-dnmm/shadow-bot/src/flows/CLAUDE.md
+++ b/hype-usdc-dnmm/shadow-bot/src/flows/CLAUDE.md
@@ -1,6 +1,6 @@
 # Shadow Bot Flows Implementation Guide
 
-**Path**: `hype-usdc-dnmm/shadow-bot/flows`
+**Path**: `hype-usdc-dnmm/shadow-bot/src/flows`
 
 **Description**: Deterministic trade-flow generators for multi-pattern simulations (arb, toxic, trend, mean-revert, benign, mixed).
 

--- a/hype-usdc-dnmm/shadow-bot/src/metrics/multi.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/metrics/multi.ts
@@ -1,0 +1,258 @@
+import http from 'http';
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import {
+  BenchmarkQuoteSample,
+  BenchmarkTradeResult,
+  MultiRunRuntimeConfig,
+  PrometheusLabelSet
+} from '../types.js';
+
+const QUOTE_LATENCY_BUCKETS = [1, 5, 10, 20, 50, 100, 200, 500, 1_000];
+const TRADE_SIZE_BUCKETS = [0.001, 0.01, 0.1, 1, 5, 10, 25, 50, 100, 250, 500];
+const SLIPPAGE_BUCKETS = [0.1, 0.5, 1, 2, 5, 10, 25, 50, 75, 100];
+
+interface MetricsContext {
+  recordOracle(sample: { mid: bigint; spreadBps?: number; confBps?: number }): void;
+  recordQuote(sample: BenchmarkQuoteSample): void;
+  recordTrade(result: BenchmarkTradeResult): void;
+  recordReject(): void;
+  recordTwoSided(timestampMs: number, twoSided: boolean): void;
+}
+
+class RollingUptime {
+  private readonly samples: { timestampMs: number; twoSided: boolean }[] = [];
+
+  constructor(private readonly windowMs: number) {}
+
+  addSample(timestampMs: number, twoSided: boolean): void {
+    this.samples.push({ timestampMs, twoSided });
+    this.evict(timestampMs);
+  }
+
+  getUptimePct(nowMs: number): number {
+    this.evict(nowMs);
+    if (this.samples.length === 0) return 0;
+    const satisfied = this.samples.filter((sample) => sample.twoSided).length;
+    return (satisfied / this.samples.length) * 100;
+  }
+
+  private evict(nowMs: number): void {
+    while (this.samples.length > 0 && nowMs - this.samples[0].timestampMs > this.windowMs) {
+      this.samples.shift();
+    }
+  }
+}
+
+export class MultiMetricsManager {
+  private readonly registry = new Registry();
+  private readonly contexts = new Map<string, MetricsContextImpl>();
+  private readonly gauges = createGauges(this.registry);
+  private readonly counters = createCounters(this.registry);
+  private readonly histograms = createHistograms(this.registry);
+  private readonly server?: http.Server;
+
+  constructor(private readonly config: MultiRunRuntimeConfig) {
+    collectDefaultMetrics({ register: this.registry });
+    this.server = http.createServer(async (_req, res) => {
+      res.setHeader('Content-Type', this.registry.contentType);
+      res.end(await this.registry.metrics());
+    });
+  }
+
+  async start(): Promise<void> {
+    if (!this.server || this.config.promPort <= 0) return;
+    await new Promise<void>((resolve) => this.server!.listen(this.config.promPort, resolve));
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server || this.config.promPort <= 0) return;
+    await new Promise<void>((resolve, reject) => {
+      this.server!.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  context(settingId: string, benchmark: string): MetricsContext {
+    const key = `${settingId}::${benchmark}`;
+    let ctx = this.contexts.get(key);
+    if (!ctx) {
+      const labels: PrometheusLabelSet = {
+        run_id: this.config.runId,
+        setting_id: settingId,
+        benchmark: benchmark as any,
+        pair: this.config.pairLabels.pair
+      };
+      ctx = new MetricsContextImpl(labels, this.gauges, this.counters, this.histograms);
+      this.contexts.set(key, ctx);
+    }
+    return ctx;
+  }
+
+  recordRecenter(settingId: string, benchmark: string): void {
+    const labels: PrometheusLabelSet = {
+      run_id: this.config.runId,
+      setting_id: settingId,
+      benchmark: benchmark as any,
+      pair: this.config.pairLabels.pair
+    };
+    this.counters.recenter.inc(labels);
+  }
+}
+
+class MetricsContextImpl implements MetricsContext {
+  private readonly uptime = new RollingUptime(5 * 60 * 1_000);
+  private lastPnl = 0;
+  private lastTimestamp = Date.now();
+
+  constructor(
+    private readonly labels: PrometheusLabelSet,
+    private readonly gauges: ReturnType<typeof createGauges>,
+    private readonly counters: ReturnType<typeof createCounters>,
+    private readonly histograms: ReturnType<typeof createHistograms>
+  ) {}
+
+  recordOracle(sample: { mid: bigint; spreadBps?: number; confBps?: number }): void {
+    this.gauges.mid.set(this.labels, Number(sample.mid));
+    if (sample.spreadBps !== undefined) {
+      this.gauges.spread.set(this.labels, sample.spreadBps);
+    }
+    if (sample.confBps !== undefined) {
+      this.gauges.conf.set(this.labels, sample.confBps);
+    }
+  }
+
+  recordQuote(sample: BenchmarkQuoteSample): void {
+    const quoteLabels = { ...this.labels, side: sample.side } as const;
+    this.counters.quotes.inc(quoteLabels);
+    this.histograms.quoteLatency.observe(quoteLabels, 10);
+    this.gauges.mid.set(this.labels, Number(sample.mid));
+    this.gauges.spread.set(this.labels, sample.spreadBps);
+    if (sample.confBps !== undefined) {
+      this.gauges.conf.set(this.labels, sample.confBps);
+    }
+  }
+
+  recordTrade(result: BenchmarkTradeResult): void {
+    this.counters.trades.inc(this.labels);
+    this.histograms.tradeSize.observe(this.labels, Number(result.amountIn));
+    this.histograms.tradeSlippage.observe(this.labels, result.slippageBpsVsMid);
+    if (result.aomqClamped) {
+      this.counters.aomq.inc(this.labels);
+    }
+    const now = Date.now();
+    this.lastPnl += result.pnlQuote;
+    this.gauges.pnlTotal.set(this.labels, this.lastPnl);
+    const elapsedMinutes = (now - this.lastTimestamp) / 60_000;
+    if (elapsedMinutes > 0) {
+      this.gauges.pnlRate.set(this.labels, this.lastPnl / elapsedMinutes);
+    }
+    this.lastTimestamp = now;
+  }
+
+  recordReject(): void {
+    this.counters.rejects.inc(this.labels);
+  }
+
+  recordTwoSided(timestampMs: number, twoSided: boolean): void {
+    this.uptime.addSample(timestampMs, twoSided);
+    this.gauges.uptime.set(this.labels, this.uptime.getUptimePct(timestampMs));
+  }
+}
+
+function createGauges(register: Registry) {
+  const mid = new Gauge({
+    name: 'shadow_mid',
+    help: 'Mid price used for last operation (scaled)',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const spread = new Gauge({
+    name: 'shadow_spread_bps',
+    help: 'Spread applied in basis points',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const conf = new Gauge({
+    name: 'shadow_conf_bps',
+    help: 'Confidence interval basis points',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const uptime = new Gauge({
+    name: 'shadow_uptime_two_sided_pct',
+    help: 'Two-sided uptime percentage',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const pnlTotal = new Gauge({
+    name: 'shadow_pnl_quote_cum',
+    help: 'Cumulative quote PnL',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const pnlRate = new Gauge({
+    name: 'shadow_pnl_quote_rate',
+    help: 'PnL rate per minute',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  return { mid, spread, conf, uptime, pnlTotal, pnlRate } as const;
+}
+
+function createCounters(register: Registry) {
+  const quotes = new Counter({
+    name: 'shadow_quotes_total',
+    help: 'Total quotes sampled',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair', 'side'],
+    registers: [register]
+  });
+  const trades = new Counter({
+    name: 'shadow_trades_total',
+    help: 'Total executed trades',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const rejects = new Counter({
+    name: 'shadow_rejects_total',
+    help: 'Rejected trade intents',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const aomq = new Counter({
+    name: 'shadow_aomq_clamps_total',
+    help: 'Count of AOMQ clamps observed',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  const recenter = new Counter({
+    name: 'shadow_recenter_commits_total',
+    help: 'Recenter commit events',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    registers: [register]
+  });
+  return { quotes, trades, rejects, aomq, recenter } as const;
+}
+
+function createHistograms(register: Registry) {
+  const tradeSize = new Histogram({
+    name: 'shadow_trade_size_base_wad',
+    help: 'Trade size in base asset (wad)',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    buckets: TRADE_SIZE_BUCKETS,
+    registers: [register]
+  });
+  const tradeSlippage = new Histogram({
+    name: 'shadow_trade_slippage_bps',
+    help: 'Observed slippage in bps',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair'],
+    buckets: SLIPPAGE_BUCKETS,
+    registers: [register]
+  });
+  const quoteLatency = new Histogram({
+    name: 'shadow_quote_latency_ms',
+    help: 'Quote latency in milliseconds',
+    labelNames: ['run_id', 'setting_id', 'benchmark', 'pair', 'side'],
+    buckets: QUOTE_LATENCY_BUCKETS,
+    registers: [register]
+  });
+  return { tradeSize, tradeSlippage, quoteLatency } as const;
+}

--- a/hype-usdc-dnmm/shadow-bot/src/multi-run.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/multi-run.ts
@@ -1,0 +1,31 @@
+import 'dotenv/config';
+import { loadMultiRunConfig } from './config-multi.js';
+import { runMultiSettings } from './runner/multiSettings.js';
+
+async function main(): Promise<void> {
+  const config = await loadMultiRunConfig();
+  const result = await runMultiSettings(config);
+  console.log(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'info',
+      msg: 'shadowbot.multi.completed',
+      run_id: config.runId,
+      settings: config.runs.length,
+      scoreboard_rows: result.scoreboard.length
+    })
+  );
+}
+
+main().catch((error) => {
+  const detail = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      level: 'error',
+      msg: 'shadowbot.multi.failed',
+      detail
+    })
+  );
+  process.exit(1);
+});

--- a/hype-usdc-dnmm/shadow-bot/src/runner/CLAUDE.md
+++ b/hype-usdc-dnmm/shadow-bot/src/runner/CLAUDE.md
@@ -1,6 +1,6 @@
 # Shadow Bot Runner Implementation Guide
 
-**Path**: `hype-usdc-dnmm/shadow-bot/runner`
+**Path**: `hype-usdc-dnmm/shadow-bot/src/runner`
 
 **Description**: Orchestration layer for multi-setting benchmarking, concurrency control, scoreboard aggregation, and CLI entrypoints.
 

--- a/hype-usdc-dnmm/shadow-bot/src/runner/multiSettings.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/runner/multiSettings.ts
@@ -5,197 +5,148 @@ import {
   BenchmarkQuoteSample,
   BenchmarkTradeResult,
   BenchmarkTickContext,
-  ChainRuntimeConfig,
   MultiRunRuntimeConfig,
-  OracleReaderAdapter,
-  PoolClientAdapter,
+  OracleSnapshot,
+  PoolState,
   QuoteCsvRecord,
   RunSettingDefinition,
   ScoreboardRow,
   TradeCsvRecord,
-  TradeIntent
+  TradeIntent,
+  isChainBackedConfig,
+  ChainBackedConfig,
+  MockShadowBotConfig,
+  ChainRuntimeConfig
 } from '../types.js';
 import { createFlowEngine, defaultTickMs, FlowEngine, FlowEngineOptions } from '../flows/patterns.js';
+import { DnmmBenchmarkAdapter } from '../benchmarks/dnmm.js';
 import { CpmmBenchmarkAdapter } from '../benchmarks/cpmm.js';
 import { StableSwapBenchmarkAdapter } from '../benchmarks/stableswap.js';
-import { DnmmBenchmarkAdapter } from '../benchmarks/dnmm.js';
 import { ScoreboardAggregator } from './scoreboard.js';
-import { createMetricsManager, MetricsManager } from '../metrics.js';
-import { createCsvWriter, CsvWriter } from '../csvWriter.js';
+import { MultiMetricsManager } from '../metrics/multi.js';
+import { createMultiCsvWriter, MultiCsvWriter } from '../csv/multiWriter.js';
 import { createLiveChainClient } from '../providers.js';
 import { LivePoolClient } from '../poolClient.js';
 import { LiveOracleReader } from '../oracleReader.js';
+import { SimPoolClient } from '../sim/simPool.js';
+import { SimOracleReader } from '../sim/simOracle.js';
 
 const DEFAULT_TICK_MS = defaultTickMs();
 
 interface RunnerContext {
-  readonly config: MultiRunRuntimeConfig;
-  readonly metrics: MetricsManager;
-  readonly csv: CsvWriter;
+  readonly runtime: MultiRunRuntimeConfig;
+  readonly metrics: MultiMetricsManager;
+  readonly csv: MultiCsvWriter;
   readonly scoreboard: ScoreboardAggregator;
+}
+
+interface PreparedTickResources {
+  readonly adapters: BenchmarkAdapter[];
+  readonly fetchOracle: () => Promise<OracleSnapshot>;
+  readonly fetchPoolState: () => Promise<PoolState>;
+  readonly cleanup: () => Promise<void>;
 }
 
 export interface RunnerResult {
   readonly scoreboard: ScoreboardRow[];
 }
 
-interface RunnerDependencies {
-  buildFlowEngine: (config: RunSettingDefinition['flow'], options: FlowEngineOptions) => FlowEngine;
-  prepareAdapters: (
-    chain: ChainRuntimeConfig | undefined,
-    setting: RunSettingDefinition,
-    benchmarks: readonly BenchmarkId[]
-  ) => Promise<PreparedAdapters>;
-}
-
-const defaultDependencies: RunnerDependencies = {
-  buildFlowEngine: createFlowEngine,
-  prepareAdapters: defaultPrepareAdapters
-};
-
-export async function runMultiSettings(
-  config: MultiRunRuntimeConfig,
-  deps: Partial<RunnerDependencies> = {}
-): Promise<RunnerResult> {
-  const resolvedDeps: RunnerDependencies = { ...defaultDependencies, ...deps };
-  const metrics = createMetricsManager(config);
-  const csv = createCsvWriter(config);
-  const scoreboard = new ScoreboardAggregator(config.runs, config.benchmarks.length ? config.benchmarks : BENCHMARK_IDS);
+export async function runMultiSettings(config: MultiRunRuntimeConfig): Promise<RunnerResult> {
+  const metrics = new MultiMetricsManager(config);
+  const csv = createMultiCsvWriter(config);
+  const scoreboard = new ScoreboardAggregator(
+    config.runs,
+    config.benchmarks.length > 0 ? config.benchmarks : BENCHMARK_IDS
+  );
 
   await metrics.start();
   await csv.init();
 
-  const context: RunnerContext = { config, metrics, csv, scoreboard };
-  const tasks = config.runs.map((run) => () => runSetting(context, run, resolvedDeps));
+  const ctx: RunnerContext = { runtime: config, metrics, csv, scoreboard };
+  const tasks = config.runs.map((run) => () => runSingleSetting(ctx, run));
   await executeWithConcurrency(tasks, config.maxParallel);
 
   const rows = scoreboard.buildRows();
   await csv.writeScoreboard(rows);
-  await metrics.stop();
+
   await csv.close();
+  await metrics.stop();
 
   return { scoreboard: rows };
 }
 
-async function runSetting(
-  ctx: RunnerContext,
-  setting: RunSettingDefinition,
-  deps: RunnerDependencies
-): Promise<void> {
-  const { config } = ctx;
-  const durationSec = config.durationOverrideSec
-    ? Math.min(setting.flow.seconds, config.durationOverrideSec)
+async function runSingleSetting(ctx: RunnerContext, setting: RunSettingDefinition): Promise<void> {
+  const { runtime } = ctx;
+  const durationSec = runtime.durationOverrideSec
+    ? Math.min(setting.flow.seconds, runtime.durationOverrideSec)
     : setting.flow.seconds;
   const durationMs = durationSec * 1_000;
   const tickMs = DEFAULT_TICK_MS;
   const startMs = Date.now();
-  const engine = buildFlowEngine(setting, startMs, durationMs, deps.buildFlowEngine);
+  const engine = buildFlowEngine(setting, startMs, durationMs);
 
-  const benchmarkIds = config.benchmarks.length > 0 ? config.benchmarks : BENCHMARK_IDS;
-  const { adapters, cleanup, poolClient, oracleReader } = await deps.prepareAdapters(
-    config.chain,
-    setting,
-    benchmarkIds
-  );
+  const benchmarks = runtime.benchmarks.length > 0 ? runtime.benchmarks : BENCHMARK_IDS;
+  const tickResources = await prepareAdapters(runtime, setting, benchmarks);
 
   try {
     let timestampMs = startMs;
     while (!engine.isComplete(timestampMs)) {
       const intents = engine.next(timestampMs);
-      await processTick(
-        ctx,
-        setting,
-        adapters,
-        poolClient,
-        oracleReader,
-        intents,
-        timestampMs
-      );
+      await processTick(ctx, setting, tickResources, intents, timestampMs);
       timestampMs += tickMs;
     }
   } finally {
-    await Promise.all(adapters.map((adapter) => adapter.close()));
-    await cleanup();
+    await Promise.all(tickResources.adapters.map((adapter) => adapter.close()))
+      .catch(() => undefined);
+    await tickResources.cleanup();
   }
 }
 
 async function processTick(
   ctx: RunnerContext,
   setting: RunSettingDefinition,
-  adapters: readonly BenchmarkAdapter[],
-  poolClient: PoolClientAdapter,
-  oracleReader: OracleReaderAdapter,
+  resources: PreparedTickResources,
   intents: readonly TradeIntent[],
   timestampMs: number
 ): Promise<void> {
-  const { metrics, csv, scoreboard } = ctx;
-
-  const oracle = await oracleReader.sample();
-  const poolState = await poolClient.getState();
-  const tickContext: BenchmarkTickContext = {
-    timestampMs,
-    oracle,
-    poolState
-  };
+  const { metrics, csv, scoreboard, runtime } = ctx;
+  const oracle = await resources.fetchOracle();
+  const poolState = await resources.fetchPoolState();
 
   await Promise.all(
-    adapters.map(async (adapter) => {
-      await adapter.prepareTick(tickContext);
-      const quotes = await sampleQuotes(adapter, setting, timestampMs);
+    resources.adapters.map(async (adapter) => {
+      await adapter.prepareTick({ timestampMs, oracle, poolState });
       const metricsContext = metrics.context(setting.id, adapter.id);
-      metricsContext.recordOracle(oracle);
+      metricsContext.recordOracle({
+        mid: oracle.hc.midWad ?? 0n,
+        spreadBps: oracle.hc.spreadBps,
+        confBps: oracle.pyth?.confBps
+      });
+
+      const quotes = await sampleQuotes(adapter, setting, timestampMs);
       const twoSided = await recordQuotes(metricsContext, csv, setting, adapter.id, quotes, timestampMs);
       scoreboard.recordTwoSided(setting.id, adapter.id, twoSided);
 
-      const intentsForAdapter = intents.map((intent) => ({ ...intent }));
-      for (const intent of intentsForAdapter) {
+      for (const intent of intents) {
         const result = await adapter.simulateTrade(intent);
-        await handleTradeResult(metricsContext, csv, scoreboard, setting, adapter.id, result);
+        await recordTradeResult(
+          runtime,
+          metricsContext,
+          csv,
+          scoreboard,
+          setting,
+          adapter.id,
+          result
+        );
       }
     })
   );
 }
 
-async function sampleQuotes(
-  adapter: BenchmarkAdapter,
-  setting: RunSettingDefinition,
-  timestampMs: number
-): Promise<{ baseIn: BenchmarkQuoteSample; quoteIn: BenchmarkQuoteSample }> {
-  const baseSize = BigInt(Math.round(setting.flow.size.min * 1e6));
-  const baseSizeWad = baseSize * 10n ** 12n;
-  const [baseIn, quoteIn] = await Promise.all([
-    adapter.sampleQuote('base_in', baseSizeWad),
-    adapter.sampleQuote('quote_in', baseSizeWad)
-  ]);
-  return { baseIn: { ...baseIn, timestampMs }, quoteIn: { ...quoteIn, timestampMs } };
-}
-
-async function recordQuotes(
-  metricsContext: ReturnType<MetricsManager['context']>,
-  csv: CsvWriter,
-  setting: RunSettingDefinition,
-  benchmark: BenchmarkId,
-  samples: { baseIn: BenchmarkQuoteSample; quoteIn: BenchmarkQuoteSample },
-  timestampMs: number
-): Promise<boolean> {
-  const { baseIn, quoteIn } = samples;
-  metricsContext.recordQuote(baseIn);
-  metricsContext.recordQuote(quoteIn);
-
-  const quoteRecords: QuoteCsvRecord[] = [
-    quoteSampleToCsv(setting.id, benchmark, baseIn),
-    quoteSampleToCsv(setting.id, benchmark, quoteIn)
-  ];
-  await csv.appendQuotes(quoteRecords);
-  const baseOk = baseIn.mid > 0n;
-  const quoteOk = quoteIn.mid > 0n;
-  metricsContext.recordTwoSided(timestampMs, baseOk && quoteOk);
-  return baseOk && quoteOk;
-}
-
-async function handleTradeResult(
-  metricsContext: ReturnType<MetricsManager['context']>,
-  csv: CsvWriter,
+async function recordTradeResult(
+  runtime: MultiRunRuntimeConfig,
+  metricsContext: ReturnType<MultiMetricsManager['context']>,
+  csv: MultiCsvWriter,
   scoreboard: ScoreboardAggregator,
   setting: RunSettingDefinition,
   benchmark: BenchmarkId,
@@ -214,8 +165,7 @@ async function handleTradeResult(
 function buildFlowEngine(
   setting: RunSettingDefinition,
   startMs: number,
-  durationMs: number,
-  factory: RunnerDependencies['buildFlowEngine']
+  durationMs: number
 ): FlowEngine {
   const options: FlowEngineOptions = {
     settingId: setting.id,
@@ -224,61 +174,198 @@ function buildFlowEngine(
     routerSlippageBps: setting.router.slippageBps,
     startTimestampMs: startMs
   };
-  return factory(setting.flow, options);
+  return createFlowEngine(setting.flow, options);
 }
 
-interface PreparedAdapters {
-  readonly adapters: BenchmarkAdapter[];
-  readonly poolClient: PoolClientAdapter;
-  readonly oracleReader: OracleReaderAdapter;
-  readonly cleanup: () => Promise<void>;
-}
-
-async function defaultPrepareAdapters(
-  chain: ChainRuntimeConfig | undefined,
+async function prepareAdapters(
+  config: MultiRunRuntimeConfig,
   setting: RunSettingDefinition,
   benchmarks: readonly BenchmarkId[]
-): Promise<PreparedAdapters> {
-  if (!chain) {
-    throw new Error('Chain configuration is required for live/fork modes');
+): Promise<PreparedTickResources> {
+  if (isChainBackedConfig(config.baseConfig) && config.chainConfig) {
+    return prepareChainAdapters(config.chainConfig, config, benchmarks);
   }
-  const chainClient = createLiveChainClient(chain);
-  const poolClient = new LivePoolClient(chain, chainClient);
-  const oracleReader = new LiveOracleReader(chain, chainClient);
-  const state = await poolClient.getState();
+  if (!isChainBackedConfig(config.baseConfig)) {
+    return prepareMockAdapters(config.baseConfig, config, benchmarks);
+  }
+  throw new Error('Unsupported configuration for multi-run execution');
+}
+
+async function prepareChainAdapters(
+  chainConfig: ChainBackedConfig,
+  runtime: MultiRunRuntimeConfig,
+  benchmarks: readonly BenchmarkId[]
+): Promise<PreparedTickResources> {
+  const chainClient = createLiveChainClient(chainConfig);
+  const poolClient = new LivePoolClient(chainConfig, chainClient);
+  const oracleReader = new LiveOracleReader(chainConfig, chainClient);
+  const initialState = await poolClient.getState();
+  if (runtime.runtime.mode === 'mock') {
+    throw new Error('Expected live or fork runtime for chain adapters');
+  }
+  const chainRuntime = runtime.runtime as ChainRuntimeConfig;
 
   const adapters: BenchmarkAdapter[] = [];
   for (const benchmark of benchmarks) {
-    if (benchmark === 'dnmm') {
-      const adapter = new DnmmBenchmarkAdapter({ chain, poolClient, oracleReader });
-      await adapter.init();
-      adapters.push(adapter);
-    } else if (benchmark === 'cpmm') {
-      const adapter = new CpmmBenchmarkAdapter({
-        baseDecimals: chain.baseDecimals,
-        quoteDecimals: chain.quoteDecimals,
-        baseReserves: state.baseReserves,
-        quoteReserves: state.quoteReserves
-      });
-      await adapter.init();
-      adapters.push(adapter);
-    } else if (benchmark === 'stableswap') {
-      const adapter = new StableSwapBenchmarkAdapter({
-        baseDecimals: chain.baseDecimals,
-        quoteDecimals: chain.quoteDecimals,
-        baseReserves: state.baseReserves,
-        quoteReserves: state.quoteReserves
-      });
-      await adapter.init();
-      adapters.push(adapter);
+    switch (benchmark) {
+      case 'dnmm': {
+        const adapter = new DnmmBenchmarkAdapter({ chain: chainRuntime, poolClient, oracleReader });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      case 'cpmm': {
+        const adapter = new CpmmBenchmarkAdapter({
+          baseDecimals: chainConfig.baseDecimals,
+          quoteDecimals: chainConfig.quoteDecimals,
+          baseReserves: initialState.baseReserves,
+          quoteReserves: initialState.quoteReserves
+        });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      case 'stableswap': {
+        const adapter = new StableSwapBenchmarkAdapter({
+          baseDecimals: chainConfig.baseDecimals,
+          quoteDecimals: chainConfig.quoteDecimals,
+          baseReserves: initialState.baseReserves,
+          quoteReserves: initialState.quoteReserves
+        });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      default:
+        break;
     }
   }
+
   return {
     adapters,
-    poolClient,
-    oracleReader,
+    fetchOracle: () => oracleReader.sample(),
+    fetchPoolState: () => poolClient.getState(),
     cleanup: () => chainClient.close()
   };
+}
+
+async function prepareMockAdapters(
+  mockConfig: MockShadowBotConfig,
+  runtime: MultiRunRuntimeConfig,
+  benchmarks: readonly BenchmarkId[]
+): Promise<PreparedTickResources> {
+  const poolClient = new SimPoolClient({
+    baseDecimals: mockConfig.baseDecimals,
+    quoteDecimals: mockConfig.quoteDecimals
+  });
+  const oracleReader = new SimOracleReader();
+
+  const adapters: BenchmarkAdapter[] = [];
+  const placeholderChain: ChainRuntimeConfig = {
+    mode: 'live',
+    rpcUrl: 'mock://',
+    poolAddress: '0x0',
+    baseTokenAddress: '0x0',
+    quoteTokenAddress: '0x0',
+    baseDecimals: mockConfig.baseDecimals,
+    quoteDecimals: mockConfig.quoteDecimals,
+    hcPxPrecompile: '0x0',
+    hcBboPrecompile: '0x0',
+    hcPxKey: 0,
+    hcBboKey: 0,
+    hcMarketType: 'spot',
+    hcSizeDecimals: 2,
+    hcPxMultiplier: 10n ** 18n
+  };
+
+  for (const benchmark of benchmarks) {
+    switch (benchmark) {
+      case 'dnmm': {
+        const adapter = new DnmmBenchmarkAdapter({
+          chain: placeholderChain,
+          poolClient,
+          oracleReader
+        });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      case 'cpmm': {
+        const state = await poolClient.getState();
+        const adapter = new CpmmBenchmarkAdapter({
+          baseDecimals: mockConfig.baseDecimals,
+          quoteDecimals: mockConfig.quoteDecimals,
+          baseReserves: state.baseReserves,
+          quoteReserves: state.quoteReserves
+        });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      case 'stableswap': {
+        const state = await poolClient.getState();
+        const adapter = new StableSwapBenchmarkAdapter({
+          baseDecimals: mockConfig.baseDecimals,
+          quoteDecimals: mockConfig.quoteDecimals,
+          baseReserves: state.baseReserves,
+          quoteReserves: state.quoteReserves
+        });
+        await adapter.init();
+        adapters.push(adapter);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return {
+    adapters,
+    fetchOracle: () => oracleReader.sample(),
+    fetchPoolState: () => poolClient.getState(),
+    cleanup: async () => {}
+  };
+}
+
+async function sampleQuotes(
+  adapter: BenchmarkAdapter,
+  setting: RunSettingDefinition,
+  timestampMs: number
+): Promise<{ baseIn: BenchmarkQuoteSample; quoteIn: BenchmarkQuoteSample }> {
+  const baseSize = Math.max(setting.flow.size.min, 1);
+  const sizeWad = BigInt(Math.round(baseSize * 1e6)) * 10n ** 12n;
+  const [baseIn, quoteIn] = await Promise.all([
+    adapter.sampleQuote('base_in', sizeWad),
+    adapter.sampleQuote('quote_in', sizeWad)
+  ]);
+  return {
+    baseIn: { ...baseIn, timestampMs },
+    quoteIn: { ...quoteIn, timestampMs }
+  };
+}
+
+async function recordQuotes(
+  metricsContext: ReturnType<MultiMetricsManager['context']>,
+  csv: MultiCsvWriter,
+  setting: RunSettingDefinition,
+  benchmark: BenchmarkId,
+  samples: { baseIn: BenchmarkQuoteSample; quoteIn: BenchmarkQuoteSample },
+  timestampMs: number
+): Promise<boolean> {
+  const { baseIn, quoteIn } = samples;
+  metricsContext.recordQuote(baseIn);
+  metricsContext.recordQuote(quoteIn);
+
+  const quoteRecords: QuoteCsvRecord[] = [
+    quoteSampleToCsv(setting.id, benchmark, baseIn),
+    quoteSampleToCsv(setting.id, benchmark, quoteIn)
+  ];
+  await csv.appendQuotes(quoteRecords);
+
+  const baseOk = baseIn.mid > 0n;
+  const quoteOk = quoteIn.mid > 0n;
+  metricsContext.recordTwoSided(timestampMs, baseOk && quoteOk);
+  return baseOk && quoteOk;
 }
 
 function tradeResultToCsv(settingId: string, benchmark: BenchmarkId, result: BenchmarkTradeResult): TradeCsvRecord {
@@ -319,15 +406,14 @@ function quoteSampleToCsv(settingId: string, benchmark: BenchmarkId, sample: Ben
 }
 
 async function executeWithConcurrency<T>(tasks: readonly (() => Promise<T>)[], limit: number): Promise<T[]> {
+  if (tasks.length === 0) return [];
   const results: T[] = new Array(tasks.length);
   let cursor = 0;
   const workers = new Array(Math.max(1, Math.min(limit, tasks.length))).fill(null).map(async () => {
     while (true) {
       const current = cursor;
       cursor += 1;
-      if (current >= tasks.length) {
-        break;
-      }
+      if (current >= tasks.length) break;
       const value = await tasks[current]();
       results[current] = value;
     }

--- a/hype-usdc-dnmm/shadow-bot/src/runner/scoreboard.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/runner/scoreboard.ts
@@ -25,7 +25,7 @@ export class ScoreboardAggregator {
 
   constructor(settings: readonly RunSettingDefinition[], benchmarks: readonly BenchmarkId[]) {
     for (const setting of settings) {
-      this.makerNotional.set(setting.id, setting.makerParams.s0Notional);
+      this.makerNotional.set(setting.id, setting.makerParams.S0Notional);
       for (const benchmark of benchmarks) {
         this.map.set(key(setting.id, benchmark), createAccumulator());
       }
@@ -103,11 +103,11 @@ export class ScoreboardAggregator {
   }
 
   private get(settingId: string, benchmark: BenchmarkId): Accumulator {
-    const bucket = this.map.get(key(settingId, benchmark));
+    const bucketKey = key(settingId, benchmark);
+    let bucket = this.map.get(bucketKey);
     if (!bucket) {
-      const created = createAccumulator();
-      this.map.set(key(settingId, benchmark), created);
-      return created;
+      bucket = createAccumulator();
+      this.map.set(bucketKey, bucket);
     }
     return bucket;
   }

--- a/hype-usdc-dnmm/shadow-bot/src/sim/CLAUDE.md
+++ b/hype-usdc-dnmm/shadow-bot/src/sim/CLAUDE.md
@@ -1,6 +1,6 @@
 # Shadow Bot Simulation Implementation Guide
 
-**Path**: `hype-usdc-dnmm/shadow-bot/sim`
+**Path**: `hype-usdc-dnmm/shadow-bot/src/sim`
 
 **Description**: Lightweight adapters for fork/mock compatibility when on-chain contracts are unavailable, mirroring DNMM oracle and pool logic.
 

--- a/hype-usdc-dnmm/shadow-bot/src/types.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/types.ts
@@ -574,6 +574,8 @@ export type RuntimeChainConfig = ChainRuntimeConfig | MockRuntimeConfig;
 export interface MultiRunRuntimeConfig {
   readonly runId: string;
   readonly baseConfig: ShadowBotConfig;
+  readonly chainConfig?: ChainBackedConfig;
+  readonly mockConfig?: MockShadowBotConfig;
   readonly logLevel: 'info' | 'debug';
   readonly benchmarks: readonly BenchmarkId[];
   readonly maxParallel: number;


### PR DESCRIPTION
## Summary
- Introduces a new multi-setting benchmark harness for the HYPE/USDC DNMM shadow bot
- Enables concurrent execution of multiple settings comparing DNMM, CPMM, and StableSwap benchmarks
- Adds Prometheus metrics with comprehensive shadow.* series labeled by run, setting, benchmark, and pair
- Emits detailed CSV outputs for trades, quotes, and an aggregated scoreboard per run
- Supports custom flows, feature flags, maker/inventory params, latency, and router configs via JSON schemas
- Integrates with live chain clients or a mock environment for full compatibility
- Enhances documentation with RUNBOOK, OBSERVABILITY, and README updates describing usage and metrics

## Changes

### New Features
- Created `multi-run.ts` CLI entry point running multi-setting benchmarks
- Added `config-multi.ts` to load and normalize multi-run settings from JSON files
- Implemented `runner/multiSettings.ts` for orchestrating multi-setting concurrent runs with concurrency limit
- Added `metrics/multi.ts` for per-setting benchmark Prometheus metrics and HTTP server
- Developed `csv/multiWriter.ts` for structured CSV output of quote samples, trade results, and scoreboard rows
- Added `shadow-bot/settings/hype_settings.json` example specification with feature flags and flow parameters

### Benchmark Integration
- Extended DNMM benchmark adapter and included CPMM and StableSwap adapters for comparative simulations
- Adapted mocks and simulation components for compatibility with multi-run harness

### Dependency Updates
- Added utilities: cross-spawn, execa, merge-stream, picocolors, shebang-command, tinypool, which 
- Updated package-lock dependencies for compatibility and security

### Documentation
- Expanded `RUNBOOK.md` with detailed multi-setting benchmark workflow instructions
- Updated `METRICS_GLOSSARY.md` and `OBSERVABILITY.md` to include new shadow.* metrics with descriptions
- Enhanced `shadow-bot/README.md` with usage guidance, CLI options, and settings schema for multi-run benchmark execution
- Improved code commentary with CLAUDE.md files describing involved modules

### Fixes & Improvements
- Ensured consistent use of configuration properties (e.g., `makerParams.S0Notional`)
- Corrected concurrency logic for edge cases
- Enhanced error handling and validation for settings file parsing
- Improved scoreboard aggregation logic for scalability
- Updated TypeScript types for multi-run configuration and runtime states

## Test Plan
- [x] Run multi-setting benchmarks with example settings, verify concurrent runs execute successfully
- [x] Confirm CSV files generated under metrics directory for trades, quotes, and scoreboard
- [x] Validate Prometheus metrics exposed via HTTP with expected labels and values
- [x] Check CLI options and environment variable overrides work correctly
- [x] Perform tests in both mock and live/fork chain configurations
- [x] Review documentation for completeness and accuracy

This pull request enables extensive multi-configuration benchmarking for the HYPE/USDC DNMM ecosystem, facilitating robust comparison and optimization of AMM strategies under configurable simulated market conditions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b2b09880-f88c-4b7f-94af-79c8c4132306