### PR TITLE
Update dependencies, add Vitest config, and implement custom env loader for shadow-bot benchmarking

### DIFF
--- a/hype-usdc-dnmm/shadow-bot/README.md
+++ b/hype-usdc-dnmm/shadow-bot/README.md
@@ -119,6 +119,8 @@ Benchmarks share the DNMM `PoolClientAdapter` interface and consume HyperCore/Py
 
 ## Configuration
 
+Environment variables are loaded by a lightweight helper (`src/env.ts`), which reads `.env.local` followed by `.env` from the project root. Values are applied to `process.env` unless already defined, so command line overrides still win. This replaces the previous `dotenv` dependency to avoid missing-module issues in sandboxed environments.
+
 ### Common variables
 
 | Variable | Default | Description |

--- a/hype-usdc-dnmm/shadow-bot/docs/ARCHITECTURE.md
+++ b/hype-usdc-dnmm/shadow-bot/docs/ARCHITECTURE.md
@@ -1,0 +1,82 @@
+# Shadow Bot Architecture
+
+This document explains how the HYPE/USDC shadow bot is organized after the TypeScript refactor and multi-setting benchmark integration.
+
+## Source Layout
+
+```
+shadow-bot/
+├─ src/
+│  ├─ env.ts              # Minimal .env loader used by all CLIs
+│  ├─ shadow-bot.ts       # Legacy single-run loop (unchanged behaviour)
+│  ├─ multi-run.ts        # Entry point for the benchmark runner
+│  ├─ config.ts           # Legacy ShadowBotConfig loader (live/fork/mock)
+│  ├─ config-multi.ts     # Multi-run settings loader / CLI parsing
+│  ├─ flows/              # Deterministic flow generators (arb, toxic, etc.)
+│  ├─ benchmarks/         # DNMM/CPMM/StableSwap adapters
+│  ├─ runner/             # Orchestrator + scoreboard utilities
+│  ├─ metrics/            # Prometheus exporters (single + multi)
+│  ├─ csv/                # Writers for single-run rows & multi-run CSVs
+│  └─ sim/                # Lightweight pool/oracle simulators for mock mode
+├─ dist/                  # Compiled JavaScript (`npm run build`)
+├─ metrics/               # CSV/scoreboard output (created at runtime)
+├─ settings/              # Example multi-run specifications
+└─ docs/                  # Architecture, runbooks, reference material
+```
+
+The baseline `runShadowBot(config)` still drives the exact same HyperCore/Pyth sampling, probe ladder, CSV writer, and Prometheus metrics as before. Multi-run functionality composes those primitives without altering live behaviour.
+
+## Execution Paths
+
+### Single Run
+1. `node dist/shadow-bot.js`
+2. `src/env.ts` loads `.env.local` then `.env` (if present) and populates `process.env`.
+3. `src/config.ts` produces a `ShadowBotConfig` (mock/fork/live).
+4. `runShadowBot()` spins the probe loop, writes `metrics/hype-metrics/shadow_summary.json`, and emits `dnmm_*` Prometheus series.
+
+### Multi-Setting Runner
+1. `node dist/multi-run.js --settings settings/hype_settings.json`
+2. `src/config-multi.ts` reads the legacy config, merges JSON settings (5–7 runs), and resolves benchmark list + output paths.
+3. `src/runner/multiSettings.ts` launches up to `MAX_PARALLEL` workers:
+   - Each worker creates adapters (DNMM via live pool client, CPMM invariant, StableSwap A-curve).
+   - Flow engines generate deterministic trade intents per tick.
+   - Quotes/trades are recorded via `src/csv/multiWriter.ts` and `src/metrics/multi.ts`.
+4. Outputs:
+   - `metrics/hype-metrics/run_<RUN_ID>/quotes/*.csv`
+   - `metrics/hype-metrics/run_<RUN_ID>/trades/*.csv`
+   - `metrics/hype-metrics/run_<RUN_ID>/scoreboard.csv`
+   - Prometheus endpoint labelled `{run_id, setting_id, benchmark, pair}` with `shadow.*` metrics.
+
+## Settings Schema
+See `settings/hype_settings.json` for an example. Each `runs[]` entry encodes feature flags, maker/inventory knobs, AOMQ params, flow pattern, latency, and router strategy. The loader enforces unique IDs and validates numeric fields before execution.
+
+## Prometheus Metrics
+- Single-run metrics retain the `dnmm_*` namespace documented in `docs/OBSERVABILITY.md`.
+- Multi-run adds `shadow_*` gauges/counters/histograms for benchmark telemetry. Refer to the updated glossary for label definitions.
+
+## Extending the Bot
+- Add new benchmarks by implementing `BenchmarkAdapter` in `src/benchmarks/` and wiring it into `runner/multiSettings.ts`.
+- Add new flow patterns by registering generators in `src/flows/patterns.ts` and updating the settings schema validator.
+- To integrate additional telemetry, extend `src/metrics/multi.ts` and update the documentation tables.
+
+## Testing Strategy
+- Unit tests live under `src/__tests__/` (Vitest). They should be run with Node 20 while npm supplies complete tarballs.
+- Golden CSV fixtures should be maintained for representative multi-run outputs.
+- CI should build the TypeScript project, execute mock-mode multi-run (short duration), and archive the scoreboard for regression tracking.
+
+## Environment Loading
+### File Precedence
+1. `.env.local`
+2. `.env`
+
+Later files supplement (not override) existing values unless `override=true` is explicitly provided.
+
+### Supported Syntax
+- `KEY=value`
+- Quoted strings (`KEY="value"`, escapes `\n`, `\r`).
+- Commented lines starting with `#` are ignored.
+
+This custom loader removes the dependency on the `dotenv` package, avoiding registry caching issues while preserving previous behaviour.
+
+---
+_Last updated: 2025-10-04_

--- a/hype-usdc-dnmm/shadow-bot/package-lock.json
+++ b/hype-usdc-dnmm/shadow-bot/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "csv-parse": "^5.5.0",
+        "debug": "^4.3.5",
         "dotenv": "^16.4.5",
+        "esbuild": "^0.21.3",
         "ethers": "^6.15.0",
         "execa": "^5.1.1",
         "isexe": "^1.1.2",
@@ -18,6 +20,7 @@
         "node-fetch": "^3.3.2",
         "path-key": "^2.0.1",
         "picocolors": "^1.0.0",
+        "pretty-format": "^27.5.1",
         "prom-client": "^15.1.1",
         "shebang-command": "^1.2.0",
         "signal-exit": "^3.0.7",
@@ -56,13 +59,12 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.3.tgz",
+      "integrity": "sha512-yTgnwQpFVYfvvo4SvRFB0SwrW8YjOxEoT7wfMT7Ol5v7v5LDNvSGo67aExmxOb87nQNeWPVvaGBNfQ7BXcrZ9w==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -73,13 +75,12 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.3.tgz",
+      "integrity": "sha512-bviJOLMgurLJtF1/mAoJLxDZDL6oU5/ztMHnJQRejbJrSc9FFu0QoUoFhvi6qSKJEw9y5oGyvr9fuDtzJ30rNQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -90,13 +91,12 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.3.tgz",
+      "integrity": "sha512-c+ty9necz3zB1Y+d/N+mC6KVVkGUUOcm4ZmT5i/Fk5arOaY3i6CA3P5wo/7+XzV8cb4GrI/Zjp8NuOQ9Lfsosw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -107,13 +107,12 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.3.tgz",
+      "integrity": "sha512-JReHfYCRK3FVX4Ra+y5EBH1b9e16TV2OxrPAvzMsGeES0X2Ndm9ImQRI4Ket757vhc5XBOuGperw63upesclRw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -124,13 +123,12 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.3.tgz",
+      "integrity": "sha512-U3fuQ0xNiAkXOmQ6w5dKpEvXQRSpHOnbw7gEfHCRXPeTKW9sBzVck6C5Yneb8LfJm0l6le4NQfkNPnWMSlTFUQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -141,13 +139,12 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.3.tgz",
+      "integrity": "sha512-3m1CEB7F07s19wmaMNI2KANLcnaqryJxO1fXHUV5j1rWn+wMxdUYoPyO2TnAbfRZdi7ADRwJClmOwgT13qlP3Q==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -158,13 +155,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.3.tgz",
+      "integrity": "sha512-fsNAAl5pU6wmKHq91cHWQT0Fz0vtyE1JauMzKotrwqIKAswwP5cpHUCxZNSTuA/JlqtScq20/5KZ+TxQdovU/g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -175,13 +171,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.3.tgz",
+      "integrity": "sha512-tci+UJ4zP5EGF4rp8XlZIdq1q1a/1h9XuronfxTMCNBslpCtmk97Q/5qqy1Mu4zIc0yswN/yP/BLX+NTUC1bXA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -192,13 +187,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.3.tgz",
+      "integrity": "sha512-f6kz2QpSuyHHg01cDawj0vkyMwuIvN62UAguQfnNVzbge2uWLhA7TCXOn83DT0ZvyJmBI943MItgTovUob36SQ==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -209,13 +203,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.3.tgz",
+      "integrity": "sha512-vvG6R5g5ieB4eCJBQevyDMb31LMHthLpXTc2IGkFnPWS/GzIFDnaYFp558O+XybTmYrVjxnryru7QRleJvmZ6Q==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -226,13 +219,12 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.3.tgz",
+      "integrity": "sha512-HjCWhH7K96Na+66TacDLJmOI9R8iDWDDiqe17C7znGvvE4sW1ECt9ly0AJ3dJH62jHyVqW9xpxZEU1jKdt+29A==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -243,13 +235,12 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.3.tgz",
+      "integrity": "sha512-BGpimEccmHBZRcAhdlRIxMp7x9PyJxUtj7apL2IuoG9VxvU/l/v1z015nFs7Si7tXUwEsvjc1rOJdZCn4QTU+Q==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -260,13 +251,12 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.3.tgz",
+      "integrity": "sha512-5rMOWkp7FQGtAH3QJddP4w3s47iT20hwftqdm7b+loe95o8JU8ro3qZbhgMRy0VuFU0DizymF1pBKkn3YHWtsw==",
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -277,13 +267,12 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.3.tgz",
+      "integrity": "sha512-h0zj1ldel89V5sjPLo5H1SyMzp4VrgN1tPkN29TmjvO1/r0MuMRwJxL8QY05SmfsZRs6TF0c/IDH3u7XYYmbAg==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -294,13 +283,12 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.3.tgz",
+      "integrity": "sha512-dkAKcTsTJ+CRX6bnO17qDJbLoW37npd5gSNtSzjYQr0svghLJYGYB0NF1SNcU1vDcjXLYS5pO4qOW4YbFama4A==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -311,13 +299,12 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.3.tgz",
+      "integrity": "sha512-vnD1YUkovEdnZWEuMmy2X2JmzsHQqPpZElXx6dxENcIwTu+Cu5ERax6+Ke1QsE814Zf3c6rxCfwQdCTQ7tPuXA==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -328,13 +315,12 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.3.tgz",
+      "integrity": "sha512-IOXOIm9WaK7plL2gMhsWJd+l2bfrhfilv0uPTptoRoSb2p09RghhQQp9YY6ZJhk/kqmeRt6siRdMSLLwzuT0KQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -345,13 +331,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-uTgCwsvQ5+vCQnqM//EfDSuomo2LhdWhFPS8VL8xKf+PKTCrcT/2kPPoWMTs22aB63MLdGMJiE3f1PHvCDmUOw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -362,13 +347,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.3.tgz",
+      "integrity": "sha512-vNAkR17Ub2MgEud2Wag/OE4HTSI6zlb291UYzHez/psiKarp0J8PKGDnAhMBcHFoOHMXHfExzmjMojJNbAStrQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -379,13 +363,12 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.3.tgz",
+      "integrity": "sha512-W8H9jlGiSBomkgmouaRoTXo49j4w4Kfbl6I1bIdO/vT0+0u4f20ko3ELzV3hPI6XV6JNBVX+8BC+ajHkvffIJA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -396,13 +379,12 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.3.tgz",
+      "integrity": "sha512-EjEomwyLSCg8Ag3LDILIqYCZAq/y3diJ04PnqGRgq8/4O3VNlXyMd54j/saShaN4h5o5mivOjAzmU6C3X4v0xw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -413,13 +395,12 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.3.tgz",
+      "integrity": "sha512-WGiE/GgbsEwR33++5rzjiYsKyHywE8QSZPF7Rfx9EBfK3Qn3xyR6IjyCr5Uk38Kg8fG4/2phN7sXp4NPWd3fcw==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -430,13 +411,12 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.3.tgz",
+      "integrity": "sha512-xRxC0jaJWDLYvcUvjQmHCJSfMrgmUuvsoXgDeU/wTorQ1ngDdUBuFtgY3W1Pc5sprGAvZBtWdJX7RPg/iZZUqA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -954,6 +934,28 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/spy": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.2.2.tgz",
@@ -982,6 +984,28 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vitest/utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1032,7 +1056,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1317,13 +1340,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
+        "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
@@ -1394,10 +1416,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.3.tgz",
+      "integrity": "sha512-Kgq0/ZsAPzKrbOjCQcjoSmPoWhlcVnGAUo7jvaLHoxW1Drto0KGkR1xBNg2Cp43b9ImvxmPEJZ9xkfcnqPsfBw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1407,29 +1428,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.21.3",
+        "@esbuild/android-arm": "0.21.3",
+        "@esbuild/android-arm64": "0.21.3",
+        "@esbuild/android-x64": "0.21.3",
+        "@esbuild/darwin-arm64": "0.21.3",
+        "@esbuild/darwin-x64": "0.21.3",
+        "@esbuild/freebsd-arm64": "0.21.3",
+        "@esbuild/freebsd-x64": "0.21.3",
+        "@esbuild/linux-arm": "0.21.3",
+        "@esbuild/linux-arm64": "0.21.3",
+        "@esbuild/linux-ia32": "0.21.3",
+        "@esbuild/linux-loong64": "0.21.3",
+        "@esbuild/linux-mips64el": "0.21.3",
+        "@esbuild/linux-ppc64": "0.21.3",
+        "@esbuild/linux-riscv64": "0.21.3",
+        "@esbuild/linux-s390x": "0.21.3",
+        "@esbuild/linux-x64": "0.21.3",
+        "@esbuild/netbsd-x64": "0.21.3",
+        "@esbuild/openbsd-x64": "0.21.3",
+        "@esbuild/sunos-x64": "0.21.3",
+        "@esbuild/win32-arm64": "0.21.3",
+        "@esbuild/win32-ia32": "0.21.3",
+        "@esbuild/win32-x64": "0.21.3"
       }
     },
     "node_modules/estree-walker": {
@@ -2001,10 +2022,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2280,18 +2300,26 @@
       "license": "ISC"
     },
     "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "react-is": "^17.0.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2321,10 +2349,9 @@
       "license": "MIT"
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
     "node_modules/readable-stream": {

--- a/hype-usdc-dnmm/shadow-bot/package-lock.json
+++ b/hype-usdc-dnmm/shadow-bot/package-lock.json
@@ -11,7 +11,6 @@
         "cross-spawn": "^7.0.3",
         "csv-parse": "^5.5.0",
         "debug": "^4.3.5",
-        "dotenv": "^16.4.5",
         "esbuild": "^0.21.3",
         "ethers": "^6.15.0",
         "execa": "^5.1.1",
@@ -1387,18 +1386,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/hype-usdc-dnmm/shadow-bot/package.json
+++ b/hype-usdc-dnmm/shadow-bot/package.json
@@ -18,7 +18,9 @@
   "dependencies": {
     "cross-spawn": "^7.0.3",
     "csv-parse": "^5.5.0",
+    "debug": "^4.3.5",
     "dotenv": "^16.4.5",
+    "esbuild": "^0.21.3",
     "ethers": "^6.15.0",
     "execa": "^5.1.1",
     "isexe": "^1.1.2",
@@ -26,6 +28,7 @@
     "node-fetch": "^3.3.2",
     "path-key": "^2.0.1",
     "picocolors": "^1.0.0",
+    "pretty-format": "^27.5.1",
     "prom-client": "^15.1.1",
     "shebang-command": "^1.2.0",
     "signal-exit": "^3.0.7",

--- a/hype-usdc-dnmm/shadow-bot/package.json
+++ b/hype-usdc-dnmm/shadow-bot/package.json
@@ -19,7 +19,6 @@
     "cross-spawn": "^7.0.3",
     "csv-parse": "^5.5.0",
     "debug": "^4.3.5",
-    "dotenv": "^16.4.5",
     "esbuild": "^0.21.3",
     "ethers": "^6.15.0",
     "execa": "^5.1.1",

--- a/hype-usdc-dnmm/shadow-bot/src/env.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/env.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface LoadEnvOptions {
+  readonly cwd?: string;
+  readonly envFile?: string;
+  readonly override?: boolean;
+}
+
+const DEFAULT_FILES = ['.env.local', '.env'];
+
+export function loadEnv(options: LoadEnvOptions = {}): Record<string, string> {
+  const cwd = options.cwd ?? process.cwd();
+  const targets = options.envFile ? [options.envFile] : DEFAULT_FILES;
+  const parsed: Record<string, string> = {};
+
+  for (const candidate of targets) {
+    const filePath = path.resolve(cwd, candidate);
+    if (!fs.existsSync(filePath)) continue;
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const entries = parseEnvFile(fileContent);
+    for (const [key, value] of Object.entries(entries)) {
+      if (!options.override && process.env[key] !== undefined) continue;
+      process.env[key] = value;
+      parsed[key] = value;
+    }
+  }
+
+  return parsed;
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = contents.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) continue;
+    const key = line.slice(0, equalsIndex).trim();
+    let value = line.slice(equalsIndex + 1).trim();
+    if (!key) continue;
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+    } else if (value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}

--- a/hype-usdc-dnmm/shadow-bot/src/monitor.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/monitor.ts
@@ -1,7 +1,9 @@
 // monitor.ts
 // Real-time monitoring and alerting system for shadow bot
 
-import 'dotenv/config';
+import { loadEnv } from './env.js';
+
+loadEnv();
 import fetch from 'node-fetch';
 import { Contract, JsonRpcProvider, formatUnits } from 'ethers';
 

--- a/hype-usdc-dnmm/shadow-bot/src/multi-run.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/multi-run.ts
@@ -1,8 +1,9 @@
-import 'dotenv/config';
+import { loadEnv } from './env.js';
 import { loadMultiRunConfig } from './config-multi.js';
 import { runMultiSettings } from './runner/multiSettings.js';
 
 async function main(): Promise<void> {
+  loadEnv();
   const config = await loadMultiRunConfig();
   const result = await runMultiSettings(config);
   console.log(

--- a/hype-usdc-dnmm/shadow-bot/src/shadow-bot.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/shadow-bot.ts
@@ -1,4 +1,6 @@
-import 'dotenv/config';
+import { loadEnv } from './env.js';
+
+loadEnv();
 import { Contract } from 'ethers';
 import { loadConfig } from './config.js';
 import { IDNM_POOL_ABI } from './abis.js';

--- a/hype-usdc-dnmm/shadow-bot/src/test-oracle.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/test-oracle.ts
@@ -1,5 +1,7 @@
 // test-oracle.ts - Diagnostic test for HYPE oracle pricing
-import 'dotenv/config';
+import { loadEnv } from './env.js';
+
+loadEnv();
 import { AbiCoder, Contract, JsonRpcProvider, getBigInt, toBeHex } from 'ethers';
 
 const RPC_URL = process.env.RPC_URL || '';

--- a/hype-usdc-dnmm/shadow-bot/src/test-precompiles.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/test-precompiles.ts
@@ -1,5 +1,7 @@
 // test-precompiles.ts - Test ALL HyperCore precompiles to find correct spot price
-import 'dotenv/config';
+import { loadEnv } from './env.js';
+
+loadEnv();
 import { AbiCoder, JsonRpcProvider } from 'ethers';
 
 const RPC_URL = process.env.RPC_URL || '';

--- a/hype-usdc-dnmm/shadow-bot/src/verify-hyperliquid.ts
+++ b/hype-usdc-dnmm/shadow-bot/src/verify-hyperliquid.ts
@@ -1,5 +1,7 @@
 // verify-hyperliquid.ts - Verify HyperLiquid is actually returning data
-import 'dotenv/config';
+import { loadEnv } from './env.js';
+
+loadEnv();
 import { AbiCoder, JsonRpcProvider } from 'ethers';
 
 const RPC_URL = process.env.RPC_URL || '';

--- a/hype-usdc-dnmm/shadow-bot/vitest.config.ts
+++ b/hype-usdc-dnmm/shadow-bot/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    pool: 'forks',
+    watch: false,
+    reporters: 'default'
+  }
+});


### PR DESCRIPTION
## Summary
- Updated dependencies in `shadow-bot` to specific versions:
  - Downgraded `debug` to 4.3.5
  - Downgraded `esbuild` to 0.21.3
  - Added `pretty-format` 27.5.1 and related dependencies including compatible `react-is` and `ms`
  - Removed `dotenv` dependency and replaced with a custom minimal `.env` loader
- Added a new Vitest configuration file for `shadow-bot` benchmarking tests
- Introduced a custom environment variables loader (`src/env.ts`) to replace `dotenv`, handling `.env.local` and `.env` files with precedence and process environment application
- Modified source files to use the new custom env loader instead of `dotenv/config`

## Changes

### Dependency Updates
- Modified `package.json` and `package-lock.json` in `hype-usdc-dnmm/shadow-bot`:
  - Added `debug` ^4.3.5
  - Added `esbuild` ^0.21.3
  - Added `pretty-format` ^27.5.1 and updated `react-is` and `ms` to compatible versions
  - Removed `dotenv` dependency

### Environment Loading
- Added `src/env.ts`:
  - Custom lightweight `.env` loader that reads `.env.local` then `.env`, replacing `dotenv` to avoid module issues in sandboxed environments
- Updated source files (`src/monitor.ts`, `src/multi-run.ts`, `src/shadow-bot.ts`, `src/test-oracle.ts`, `src/test-precompiles.ts`, `src/verify-hyperliquid.ts`) to import and use the new `loadEnv` function

### Testing Setup
- Created `vitest.config.ts`:
  - Configured Vitest test runner with:
    - Global test environment for Node.js
    - Use the 'forks' pool
    - Disabled watch mode
    - Default reporters enabled

## Test plan
- Run `npm install` in `shadow-bot` directory to ensure dependencies resolve correctly
- Execute `vitest` to confirm tests run with the new configuration
- Verify benchmarking tasks execute without errors
- Confirm no regressions or compatibility warnings from downgraded dependencies
- Validate that environment variables load properly with the new `loadEnv` implementation and replace previous `dotenv` functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b2b09880-f88c-4b7f-94af-79c8c4132306