### PR TITLE
Update LvrFeeRespectsCaps test to match new fee cap and parameters

### DIFF
--- a/hype-usdc-dnmm/test/unit/LvrFee_RespectsCaps.t.sol
+++ b/hype-usdc-dnmm/test/unit/LvrFee_RespectsCaps.t.sol
@@ -12,11 +12,11 @@ contract LvrFeeRespectsCapsTest is BaseTest {
 
         FeePolicy.FeeConfig memory feeCfg = defaultFeeConfig();
         feeCfg.baseBps = 0;
-        feeCfg.capBps = 50;
+        feeCfg.capBps = 500;
         feeCfg.gammaSizeLinBps = 0;
         feeCfg.gammaSizeQuadBps = 0;
         feeCfg.sizeFeeCapBps = 0;
-        feeCfg.kappaLvrBps = 2_000; // aggressive coefficient to try exceed cap
+        feeCfg.kappaLvrBps = 2_000; // aggressive coefficient; cap should still bound fee
         vm.prank(gov);
         pool.updateParams(IDnmPool.ParamKind.Fee, abi.encode(feeCfg));
 
@@ -37,6 +37,6 @@ contract LvrFeeRespectsCapsTest is BaseTest {
 
     function test_lvrFeeNeverExceedsCap() public {
         IDnmPool.QuoteResult memory res = quote(20_000 ether, true, IDnmPool.OracleMode.Spot);
-        assertLe(res.feeBpsUsed, 50, "fee capped by policy");
+        assertLe(res.feeBpsUsed, 500, "fee capped by policy");
     }
 }


### PR DESCRIPTION
## Summary
- Adjusts the unit test `LvrFeeRespectsCaps` to reflect updated fee cap configuration
- Increases the `capBps` from 50 to 500 in the fee configuration
- Updates test assertion to ensure the leveraged fee does not exceed the new cap of 500 bps

## Changes

### Test Updates
- Modified `feeCfg.capBps` in `LvrFee_RespectsCaps.t.sol` from `50` to `500`
- Updated `test_lvrFeeNeverExceedsCap` assertion to verify that `feeBpsUsed` is at most `500` instead of `50`

This ensures the test aligns with the new fee cap policy and validates the leveraged fee respects the updated cap.

## Test plan
- Run unit tests in `hype-usdc-dnmm` suite to confirm all assertions pass
- Verify that no leveraged fee exceeds the updated cap during testing

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6a9a7747-5b2c-44df-9ca5-45c12b7d3f35